### PR TITLE
chore(commitizen): add config + pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/commitizen-tools/commitizen
+    rev: master
+    hooks:
+      - id: commitizen
+      - id: commitizen-branch
+        stages: [push]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,15 @@ warn_unreachable = true
 [tool.isort]
 profile = "black"
 
+[tool.commitizen]
+name = "cz_conventional_commits"
+tag_format = "$version"
+version_scheme = "pep440"
+version_provider = "poetry"
+update_changelog_on_bump = true
+major_version_zero = true
+changelog_incremental = true
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
# Pull Request

## Changes

Add commitizen configuration to `pyproject.toml` and (an optional) pre-commit hook.

## Why this change?

In order to maintain conventional commits along with its benefits: bumping versions, changelog generation, etc.

## Testing

How was the change tested?

## Additional Notes

Any additional information or context you want to provide?
