### PR TITLE
feat(api): add an api call for GET /users/me

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Feat
+
+- **api**: add an api call for GET /users/me
+
 ## 0.3.0 (2024-03-19)
 
 ### Refactor

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ A Python wrapper for the MOSTLY AI platform (https://app.mostly.ai/).
 | Generate unlimited synthetic data on demand     | `mostly.generate(g, size)` |
 | Prompt the generator for the data that you need | `mostly.generate(g, seed)` |
 | Connect to any data source within your org      | `mostly.connect(config)`   |
+| Info about the current user                     | `mostly.me()`              |
+
 
 
 

--- a/mostlyai/api.py
+++ b/mostlyai/api.py
@@ -4,11 +4,12 @@ from typing import Any, Optional, Union
 import pandas as pd
 import rich
 
-from mostlyai.base import _MostlyBaseClient
+from mostlyai.base import GET, _MostlyBaseClient
 from mostlyai.connectors import _MostlyConnectorsClient
 from mostlyai.generators import _MostlyGeneratorsClient
 from mostlyai.model import (
     Connector,
+    CurrentUser,
     Generator,
     PermissionLevel,
     ProgressStatus,
@@ -321,3 +322,11 @@ class MostlyAI(_MostlyBaseClient):
         rich.print(
             f"Revoked access of resource [bold cyan]{resource.id}[/] for [bold]{user_email}[/]"
         )
+
+    def me(self) -> CurrentUser:
+        """
+        Retrieve current user info.
+
+        :return: info about the current user.
+        """
+        return self.request(verb=GET, path=["users", "me"], response_type=CurrentUser)

--- a/mostlyai/base.py
+++ b/mostlyai/base.py
@@ -53,8 +53,10 @@ class _MostlyBaseClient:
         self.api_key = api_key or os.getenv("MOSTLY_API_KEY")
         self.timeout = timeout
         if not self.api_key:
-            raise APIError("The API key must be either set by passing api_key to the client or by specifying a "
-                           "MOSTLY_API_KEY environment variable")
+            raise APIError(
+                "The API key must be either set by passing api_key to the client or by specifying a "
+                "MOSTLY_API_KEY environment variable"
+            )
 
     def headers(self):
         return {


### PR DESCRIPTION
# Pull Request

## Changes

Support for `mostly.me()` to retrieve current user info

## Why this change?

Easy pythonic access to `GET /users/me`

## Testing

How was the change tested?

## Additional Notes

Any additional information or context you want to provide?
