### PR TITLE
feat(api): allow setting ssl verify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### Feat
 
-- **api**: add an api call for GET /users/me
+- **api**: allow setting ssl verify
+- **api**: add an api call for GET /users/me (#10)
 
 ## 0.3.0 (2024-03-19)
 

--- a/mostlyai/api.py
+++ b/mostlyai/api.py
@@ -31,6 +31,7 @@ class MostlyAI(_MostlyBaseClient):
     :param base_url: The base URL. If not provided, a default value is used.
     :param api_key: The API key for authenticating. If not provided, it would rely on env vars.
     :param timeout: Timeout for HTTPS requests in seconds.
+    :param ssl_verify: Whether to verify SSL certificates.
     """
 
     def __init__(
@@ -38,12 +39,16 @@ class MostlyAI(_MostlyBaseClient):
         base_url: Optional[str] = None,
         api_key: Optional[str] = None,
         timeout: float = 60.0,
+        ssl_verify: bool = True,
     ):
-        super().__init__(base_url=base_url, api_key=api_key, timeout=timeout)
+        super().__init__(
+            base_url=base_url, api_key=api_key, timeout=timeout, ssl_verify=ssl_verify
+        )
         client_kwargs = {
             "base_url": self.base_url,
             "api_key": self.api_key,
             "timeout": self.timeout,
+            "ssl_verify": self.ssl_verify,
         }
         self.connectors = _MostlyConnectorsClient(**client_kwargs)
         self.generators = _MostlyGeneratorsClient(**client_kwargs)

--- a/mostlyai/base.py
+++ b/mostlyai/base.py
@@ -46,12 +46,14 @@ class _MostlyBaseClient:
         base_url: Optional[str] = None,
         api_key: Optional[str] = None,
         timeout: float = 60.0,
+        ssl_verify: bool = True,
     ):
         self.base_url = (
             base_url or os.getenv("MOSTLY_BASE_URL") or DEFAULT_BASE_URL
         ).rstrip("/")
         self.api_key = api_key or os.getenv("MOSTLY_API_KEY")
         self.timeout = timeout
+        self.ssl_verify = ssl_verify
         if not self.api_key:
             raise APIError(
                 "The API key must be either set by passing api_key to the client or by specifying a "
@@ -104,7 +106,7 @@ class _MostlyBaseClient:
             )
 
         try:
-            with httpx.Client(timeout=self.timeout) as client:
+            with httpx.Client(timeout=self.timeout, verify=self.ssl_verify) as client:
                 response = client.request(method=verb, url=full_url, **kwargs)
             response.raise_for_status()
         except httpx.HTTPStatusError as exc:


### PR DESCRIPTION
# Pull Request

## Changes

Allow setting SSL `verify` flag.

## Why this change?

For the case of self-signed SSL certificates, one could disable the verification:
```python
mostly = MostlyAI(..., ssl_verify=False)
```

## Testing

How was the change tested?

## Additional Notes

Any additional information or context you want to provide?
