### PR TITLE
feat(api): add search_term parameter for lists

### DIFF
--- a/mostlyai/connectors.py
+++ b/mostlyai/connectors.py
@@ -15,6 +15,7 @@ class _MostlyConnectorsClient(_MostlyBaseClient, _MostlySharesMixin):
         offset: int = 0,
         limit: int = 50,
         access_type: Optional[str] = None,
+        search_term: Optional[str] = None,
     ) -> Iterator[Connector]:
         """
         List connectors.
@@ -25,10 +26,16 @@ class _MostlyConnectorsClient(_MostlyBaseClient, _MostlySharesMixin):
         :param offset: Offset the entities in the response. Optional. Default: 0
         :param limit: Limit the number of entities in the response. Optional. Default: 50
         :param access_type: Filter by access type. Possible values: "SOURCE", "DESTINATION"
+        :param search_term: Filter by string in name. Optional
         :return: Iterator over connectors.
         """
         with Paginator(
-            self, Connector, offset=offset, limit=limit, access_type=access_type
+            self,
+            Connector,
+            offset=offset,
+            limit=limit,
+            access_type=access_type,
+            search_term=search_term,
         ) as paginator:
             for item in paginator:
                 yield item

--- a/mostlyai/generators.py
+++ b/mostlyai/generators.py
@@ -19,6 +19,7 @@ class _MostlyGeneratorsClient(_MostlyBaseClient, _MostlySharesMixin):
         offset: int = 0,
         limit: int = 50,
         status: Optional[Union[str, list[str]]] = None,
+        search_term: Optional[str] = None,
     ) -> Iterator[Generator]:
         """
         List generators.
@@ -28,11 +29,17 @@ class _MostlyGeneratorsClient(_MostlyBaseClient, _MostlySharesMixin):
         :param offset: Offset the entities in the response. Optional. Default: 0
         :param limit: Limit the number of entities in the response. Optional. Default: 50
         :param status: Filter by training status. Optional. Default: None
+        :param search_term: Filter by string in name or description. Optional
         :return: Iterator over generators.
         """
         status = ",".join(status) if isinstance(status, list) else status
         with Paginator(
-            self, Generator, offset=offset, limit=limit, status=status
+            self,
+            Generator,
+            offset=offset,
+            limit=limit,
+            status=status,
+            search_term=search_term,
         ) as paginator:
             for item in paginator:
                 yield item

--- a/mostlyai/synthetic_datasets.py
+++ b/mostlyai/synthetic_datasets.py
@@ -21,6 +21,7 @@ class _MostlySyntheticDatasetsClient(_MostlyBaseClient):
         offset: int = 0,
         limit: int = 50,
         status: Optional[Union[str, list[str]]] = None,
+        search_term: Optional[str] = None,
     ) -> Iterator[SyntheticDataset]:
         """
         List synthetic datasets.
@@ -30,11 +31,17 @@ class _MostlySyntheticDatasetsClient(_MostlyBaseClient):
         :param offset: Offset the entities in the response. Optional. Default: 0
         :param limit: Limit the number of entities in the response. Optional. Default: 50
         :param status: Filter by generation status. Optional. Default: None
+        :param search_term: Filter by string in name or description. Optional
         :return: Iterator over synthetic datasets.
         """
         status = ",".join(status) if isinstance(status, list) else status
         with Paginator(
-            self, SyntheticDataset, offset=offset, limit=limit, status=status
+            self,
+            SyntheticDataset,
+            offset=offset,
+            limit=limit,
+            status=status,
+            search_term=search_term,
         ) as paginator:
             for item in paginator:
                 yield item


### PR DESCRIPTION
Filter lists of connectors, generators and synthetic datasets (by string in name).

# Pull Request

## Changes

Search in lists (connectors, generators, synthetic datasets) by a string in resource's name.

## Why this change?

Easier filtering.

## Testing

How was the change tested?

## Additional Notes

Any additional information or context you want to provide?
