### PR TITLE
docs(examples): remove an empty page and refernces to it

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -19,9 +19,6 @@ This documentation is your guide to using the MOSTLY AI Python wrapper, providin
 - [What's New](home/changelog.md): Stay up-to-date with the latest updates and enhancements.
 - [Legal Information](home/license.md): Review the legal terms and conditions of using our platform.
 
-### Usage
-- [Examples](usage/examples.md): Explore practical examples and use cases.
-
 ### API Reference
 - [API](api_reference/api.md): The gateway to our API.
 - [Model](api_reference/model.md): Insights into the pydantic models used by our python wrapper.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,8 +52,6 @@ nav:
     - Readme: home/readme.md
     - What's New: home/changelog.md
     - Legal: home/license.md
-  - Usage:
-      - Examples: usage/examples.md
   - API Reference:
     - API: api_reference/api.md
     - Model: api_reference/model.md


### PR DESCRIPTION
# Pull Request

## Changes

Remove an empty page, containing (no) examples, at this point.

## Why this change?

Explain the reason for the change.

## Testing

How was the change tested?

## Additional Notes

Any additional information or context you want to provide?
