### PR TITLE
feat(api): make progress bar optional

### DIFF
--- a/mostlyai/api.py
+++ b/mostlyai/api.py
@@ -195,6 +195,7 @@ class MostlyAI(_MostlyBaseClient):
         name: Optional[str] = None,
         start: bool = True,
         wait: bool = True,
+        progress_bar: bool = True,
     ) -> Generator:
         """
         Train a generator
@@ -204,6 +205,7 @@ class MostlyAI(_MostlyBaseClient):
         :param name: Optional. The name of the generator.
         :param start: If true, then training is started right away. Default: true.
         :param wait: If true, then the function only returns once training has finished. Default: true.
+        :param progress_bar: If true, then the progress bar will be displayed.
         :return: The created generator.
         """
         if data is not None and config is not None:
@@ -229,7 +231,7 @@ class MostlyAI(_MostlyBaseClient):
             g.training.start()
             rich.print("Started generator training")
         if start and wait:
-            g = g.training.wait()
+            g = g.training.wait(progress_bar=progress_bar)
             if g.training_status == ProgressStatus.done:
                 rich.print(
                     ":tada: [bold green]Your generator is ready![/] "
@@ -247,6 +249,7 @@ class MostlyAI(_MostlyBaseClient):
         name: Optional[str] = None,
         start: bool = True,
         wait: bool = True,
+        progress_bar: bool = True,
     ) -> SyntheticDataset:
         """
         Generate synthetic data
@@ -258,6 +261,7 @@ class MostlyAI(_MostlyBaseClient):
         :param name: Optional. The name of the synthetic dataset.
         :param start: If true, then generation is started right away. Default: true.
         :param wait: If true, then the function only returns once generation has finished. Default: true.
+        :param progress_bar: If true, then the progress bar will be displayed.
         :return: The created synthetic dataset.
         """
         config = _harmonize_sd_config(generator, size, seed, config, name)
@@ -272,7 +276,7 @@ class MostlyAI(_MostlyBaseClient):
             sd.generation.start()
             rich.print("Started synthetic dataset generation")
         if start and wait:
-            sd = sd.generation.wait()
+            sd = sd.generation.wait(progress_bar=progress_bar)
             if sd.generation_status == ProgressStatus.done:
                 rich.print(
                     ":tada: [bold green]Your synthetic dataset is ready![/] "

--- a/mostlyai/api.py
+++ b/mostlyai/api.py
@@ -205,7 +205,7 @@ class MostlyAI(_MostlyBaseClient):
         :param name: Optional. The name of the generator.
         :param start: If true, then training is started right away. Default: true.
         :param wait: If true, then the function only returns once training has finished. Default: true.
-        :param progress_bar: If true, then the progress bar will be displayed.
+        :param progress_bar: If true, then the progress bar will be displayed, in case of wait=True
         :return: The created generator.
         """
         if data is not None and config is not None:
@@ -261,7 +261,7 @@ class MostlyAI(_MostlyBaseClient):
         :param name: Optional. The name of the synthetic dataset.
         :param start: If true, then generation is started right away. Default: true.
         :param wait: If true, then the function only returns once generation has finished. Default: true.
-        :param progress_bar: If true, then the progress bar will be displayed.
+        :param progress_bar: If true, then the progress bar will be displayed, in case of wait=True
         :return: The created synthetic dataset.
         """
         config = _harmonize_sd_config(generator, size, seed, config, name)

--- a/mostlyai/generators.py
+++ b/mostlyai/generators.py
@@ -108,7 +108,9 @@ class _MostlyGeneratorsClient(_MostlyBaseClient, _MostlySharesMixin):
         )
         return response
 
-    def _training_wait(self, generator_id: str, progress_bar: bool, interval: float) -> Generator:
+    def _training_wait(
+        self, generator_id: str, progress_bar: bool, interval: float
+    ) -> Generator:
         if progress_bar:
             _job_wait(lambda: self._training_progress(generator_id), interval)
         generator = self.get(generator_id)

--- a/mostlyai/generators.py
+++ b/mostlyai/generators.py
@@ -111,7 +111,6 @@ class _MostlyGeneratorsClient(_MostlyBaseClient, _MostlySharesMixin):
     def _training_wait(
         self, generator_id: str, progress_bar: bool, interval: float
     ) -> Generator:
-        if progress_bar:
-            _job_wait(lambda: self._training_progress(generator_id), interval)
+        _job_wait(lambda: self._training_progress(generator_id), interval, progress_bar)
         generator = self.get(generator_id)
         return generator

--- a/mostlyai/generators.py
+++ b/mostlyai/generators.py
@@ -108,7 +108,8 @@ class _MostlyGeneratorsClient(_MostlyBaseClient, _MostlySharesMixin):
         )
         return response
 
-    def _training_wait(self, generator_id: str, interval: float) -> Generator:
-        _job_wait(lambda: self._training_progress(generator_id), interval)
+    def _training_wait(self, generator_id: str, progress_bar: bool, interval: float) -> Generator:
+        if progress_bar:
+            _job_wait(lambda: self._training_progress(generator_id), interval)
         generator = self.get(generator_id)
         return generator

--- a/mostlyai/model.py
+++ b/mostlyai/model.py
@@ -1204,14 +1204,15 @@ class SyntheticDataset(CustomBaseModel):
                 self.synthetic_dataset.id
             )
 
-        def wait(self, interval: float = 2) -> "SyntheticDataset":
+        def wait(self, progress_bar: bool, interval: float = 2) -> "SyntheticDataset":
             """
             Poll generation progress and loop until generation has completed
 
+            :param progress_bar: If true, then the progress bar will be displayed.
             :param interval: The interval in seconds to poll the job progress
             """
             return self.synthetic_dataset.client._generation_wait(
-                self.synthetic_dataset.id, interval=interval
+                self.synthetic_dataset.id, progress_bar=progress_bar, interval=interval
             )
 
 
@@ -1307,14 +1308,15 @@ class Generator(CustomBaseModel):
             """
             return self.generator.client._training_progress(self.generator.id)
 
-        def wait(self, interval: float = 2) -> "Generator":
+        def wait(self, progress_bar: bool, interval: float = 2) -> "Generator":
             """
             Poll training progress and loop until training has completed
 
+            :param progress_bar: If true, then the progress bar will be displayed.
             :param interval: The interval in seconds to poll the job progress
             """
             return self.generator.client._training_wait(
-                self.generator.id, interval=interval
+                self.generator.id, progress_bar=progress_bar, interval=interval
             )
 
         def list_synthetic_dataset(self) -> list["SyntheticDataset"]:

--- a/mostlyai/model.py
+++ b/mostlyai/model.py
@@ -893,9 +893,9 @@ class User(CustomBaseModel):
         Optional[str], Field(None, description="The unique identifier of a user")
     ] = None
     name: Annotated[Optional[str], Field(None, description="The name of a user")] = None
-    email: Annotated[
-        Optional[str], Field(None, description="The email of a user")
-    ] = None
+    email: Annotated[Optional[str], Field(None, description="The email of a user")] = (
+        None
+    )
 
 
 class CurrentUser(CustomBaseModel):
@@ -903,9 +903,9 @@ class CurrentUser(CustomBaseModel):
         Optional[str], Field(None, description="The unique identifier of a user")
     ] = None
     name: Annotated[Optional[str], Field(None, description="The name of a user")] = None
-    email: Annotated[
-        Optional[str], Field(None, description="The email of a user")
-    ] = None
+    email: Annotated[Optional[str], Field(None, description="The email of a user")] = (
+        None
+    )
     settings: Optional[Dict[str, Any]] = None
     usage: Optional[UserUsage] = None
 
@@ -1035,9 +1035,9 @@ class SourceTable(CustomBaseModel):
 
 
 class Probe(CustomBaseModel):
-    name: Annotated[
-        Optional[str], Field(None, description="The name of the table")
-    ] = None
+    name: Annotated[Optional[str], Field(None, description="The name of the table")] = (
+        None
+    )
     rows: Optional[List[Dict[str, Any]]] = None
 
 

--- a/mostlyai/model.py
+++ b/mostlyai/model.py
@@ -893,9 +893,9 @@ class User(CustomBaseModel):
         Optional[str], Field(None, description="The unique identifier of a user")
     ] = None
     name: Annotated[Optional[str], Field(None, description="The name of a user")] = None
-    email: Annotated[Optional[str], Field(None, description="The email of a user")] = (
-        None
-    )
+    email: Annotated[
+        Optional[str], Field(None, description="The email of a user")
+    ] = None
 
 
 class CurrentUser(CustomBaseModel):
@@ -903,9 +903,9 @@ class CurrentUser(CustomBaseModel):
         Optional[str], Field(None, description="The unique identifier of a user")
     ] = None
     name: Annotated[Optional[str], Field(None, description="The name of a user")] = None
-    email: Annotated[Optional[str], Field(None, description="The email of a user")] = (
-        None
-    )
+    email: Annotated[
+        Optional[str], Field(None, description="The email of a user")
+    ] = None
     settings: Optional[Dict[str, Any]] = None
     usage: Optional[UserUsage] = None
 
@@ -1035,9 +1035,9 @@ class SourceTable(CustomBaseModel):
 
 
 class Probe(CustomBaseModel):
-    name: Annotated[Optional[str], Field(None, description="The name of the table")] = (
-        None
-    )
+    name: Annotated[
+        Optional[str], Field(None, description="The name of the table")
+    ] = None
     rows: Optional[List[Dict[str, Any]]] = None
 
 

--- a/mostlyai/synthetic_datasets.py
+++ b/mostlyai/synthetic_datasets.py
@@ -164,8 +164,7 @@ class _MostlySyntheticDatasetsClient(_MostlyBaseClient):
     def _generation_wait(
         self, synthetic_dataset_id: str, progress_bar: bool, interval: float
     ) -> SyntheticDataset:
-        if progress_bar:
-            _job_wait(lambda: self._generation_progress(synthetic_dataset_id), interval)
+        _job_wait(lambda: self._generation_progress(synthetic_dataset_id), interval, progress_bar)
         synthetic_dataset = self.get(synthetic_dataset_id)
         return synthetic_dataset
 

--- a/mostlyai/synthetic_datasets.py
+++ b/mostlyai/synthetic_datasets.py
@@ -164,7 +164,11 @@ class _MostlySyntheticDatasetsClient(_MostlyBaseClient):
     def _generation_wait(
         self, synthetic_dataset_id: str, progress_bar: bool, interval: float
     ) -> SyntheticDataset:
-        _job_wait(lambda: self._generation_progress(synthetic_dataset_id), interval, progress_bar)
+        _job_wait(
+            lambda: self._generation_progress(synthetic_dataset_id),
+            interval,
+            progress_bar,
+        )
         synthetic_dataset = self.get(synthetic_dataset_id)
         return synthetic_dataset
 

--- a/mostlyai/synthetic_datasets.py
+++ b/mostlyai/synthetic_datasets.py
@@ -162,9 +162,10 @@ class _MostlySyntheticDatasetsClient(_MostlyBaseClient):
         return response
 
     def _generation_wait(
-        self, synthetic_dataset_id: str, interval: float
+        self, synthetic_dataset_id: str, progress_bar: bool, interval: float
     ) -> SyntheticDataset:
-        _job_wait(lambda: self._generation_progress(synthetic_dataset_id), interval)
+        if progress_bar:
+            _job_wait(lambda: self._generation_progress(synthetic_dataset_id), interval)
         synthetic_dataset = self.get(synthetic_dataset_id)
         return synthetic_dataset
 

--- a/mostlyai/utils.py
+++ b/mostlyai/utils.py
@@ -114,7 +114,10 @@ def _job_wait(
                     progress.stop()
                     return
             else:
-                if job.end_date or job.progress in (ProgressStatus.failed, ProgressStatus.canceled):
+                if job.end_date or job.progress in (
+                    ProgressStatus.failed,
+                    ProgressStatus.canceled,
+                ):
                     rich.print(f"Job {job.status.lower()}")
                     return
     except KeyboardInterrupt:

--- a/tools/custom_template/pydantic_v2/BaseModel.jinja2
+++ b/tools/custom_template/pydantic_v2/BaseModel.jinja2
@@ -166,14 +166,15 @@ class {{ class_name }}({{ base_class }}):{% if comment is defined %}  # {{ comme
             """
             return self.generator.client._training_progress(self.generator.id)
 
-        def wait(self, interval: float = 2) -> "Generator":
+        def wait(self, progress_bar: bool, interval: float = 2) -> "Generator":
             """
             Poll training progress and loop until training has completed
 
+            :param progress_bar: If true, then the progress bar will be displayed.
             :param interval: The interval in seconds to poll the job progress
             """
             return self.generator.client._training_wait(
-                self.generator.id, interval=interval
+                self.generator.id, progress_bar=progress_bar, interval=interval
             )
 
         def list_synthetic_dataset(self) -> list["SyntheticDataset"]:
@@ -331,13 +332,14 @@ class {{ class_name }}({{ base_class }}):{% if comment is defined %}  # {{ comme
                 self.synthetic_dataset.id
             )
 
-        def wait(self, interval: float = 2) -> "SyntheticDataset":
+        def wait(self, progress_bar: bool, interval: float = 2) -> "SyntheticDataset":
             """
             Poll generation progress and loop until generation has completed
 
+            :param progress_bar: If true, then the progress bar will be displayed.
             :param interval: The interval in seconds to poll the job progress
             """
             return self.synthetic_dataset.client._generation_wait(
-                self.synthetic_dataset.id, interval=interval
+                self.synthetic_dataset.id, progress_bar=progress_bar, interval=interval
             )
 {%- endif %}

--- a/tools/model.py
+++ b/tools/model.py
@@ -137,14 +137,15 @@ class Generator:
             """
             return self.generator.client._training_progress(self.generator.id)
 
-        def wait(self, interval: float = 2) -> "Generator":
+        def wait(self, progress_bar: bool, interval: float = 2) -> "Generator":
             """
             Poll training progress and loop until training has completed
 
+            :param progress_bar: If true, then the progress bar will be displayed.
             :param interval: The interval in seconds to poll the job progress
             """
             return self.generator.client._training_wait(
-                self.generator.id, interval=interval
+                self.generator.id, progress_bar=progress_bar, interval=interval
             )
 
         def list_synthetic_dataset(self) -> list["SyntheticDataset"]:
@@ -257,12 +258,13 @@ class SyntheticDataset:
                 self.synthetic_dataset.id
             )
 
-        def wait(self, interval: float = 2) -> "SyntheticDataset":
+        def wait(self, progress_bar: bool, interval: float = 2) -> "SyntheticDataset":
             """
             Poll generation progress and loop until generation has completed
 
+            :param progress_bar: If true, then the progress bar will be displayed.
             :param interval: The interval in seconds to poll the job progress
             """
             return self.synthetic_dataset.client._generation_wait(
-                self.synthetic_dataset.id, interval=interval
+                self.synthetic_dataset.id, progress_bar=progress_bar, interval=interval
             )


### PR DESCRIPTION
# Pull Request

## Changes

Allow having the progress bar optional (when starting and waiting) for both `train` and `generate`.

## Why this change?

Allow for flexibility according to the needs.

## Testing

How was the change tested?

## Additional Notes

Any additional information or context you want to provide?
