### PR TITLE
feat(api): allow `columns` to be provided as list[str] instead of list[dict[str, str]] in `mostly.train`

### DIFF
--- a/mostlyai/generators.py
+++ b/mostlyai/generators.py
@@ -73,8 +73,8 @@ class _MostlyGeneratorsClient(_MostlyBaseClient, _MostlySharesMixin):
         # convert `columns` to dict, if provided as list
         if "tables" in config and config["tables"]:
             for table in config["tables"]:
-                if "columns" in table and isinstance(table["columns"], list):
-                    table["columns"] = [{"name": col} for col in table["columns"]]
+                if "columns" in table and table["columns"]:
+                    table["columns"] = [{"name": col} if isinstance(col, str) else col for col in table["columns"]]
 
         generator = self.request(
             verb=POST, path=[], json=config, response_type=Generator

--- a/mostlyai/generators.py
+++ b/mostlyai/generators.py
@@ -70,6 +70,11 @@ class _MostlyGeneratorsClient(_MostlyBaseClient, _MostlySharesMixin):
                         table["data"] = _convert_to_base64(table["data"])
                     else:
                         raise ValueError("data must be a DataFrame or a file path")
+        # convert `columns` to dict, if provided as list
+        if "tables" in config and config["tables"]:
+            for table in config["tables"]:
+                if "columns" in table and isinstance(table["columns"], list):
+                    table["columns"] = [{"name": col} for col in table["columns"]]
 
         generator = self.request(
             verb=POST, path=[], json=config, response_type=Generator

--- a/mostlyai/generators.py
+++ b/mostlyai/generators.py
@@ -74,7 +74,10 @@ class _MostlyGeneratorsClient(_MostlyBaseClient, _MostlySharesMixin):
         if "tables" in config and config["tables"]:
             for table in config["tables"]:
                 if "columns" in table and table["columns"]:
-                    table["columns"] = [{"name": col} if isinstance(col, str) else col for col in table["columns"]]
+                    table["columns"] = [
+                        {"name": col} if isinstance(col, str) else col
+                        for col in table["columns"]
+                    ]
 
         generator = self.request(
             verb=POST, path=[], json=config, response_type=Generator

--- a/mostlyai/generators.py
+++ b/mostlyai/generators.py
@@ -70,7 +70,7 @@ class _MostlyGeneratorsClient(_MostlyBaseClient, _MostlySharesMixin):
                         table["data"] = _convert_to_base64(table["data"])
                     else:
                         raise ValueError("data must be a DataFrame or a file path")
-        # convert `columns` to dict, if provided as list
+        # convert `columns` to list[dict], if provided as list[str]
         if "tables" in config and config["tables"]:
             for table in config["tables"]:
                 if "columns" in table and table["columns"]:


### PR DESCRIPTION
This allows to simply specify 
```
mostly.train(config={
    'tables': [
        {
            'data': 'census.csv.gz',
            'columns': ['age', 'workclass']
        }
    ]})
```
instead of 
```
mostly.train(config={
    'tables': [
        {
            'data': 'census.csv.gz',
            'columns': [
               {'name': 'age'},
               {'name': 'workclass'}
            ]
        }
    ]})
```