### PR TITLE
fix(base): repr pydantic model without deprecation warning

### DIFF
--- a/mostlyai/base.py
+++ b/mostlyai/base.py
@@ -210,7 +210,7 @@ class CustomBaseModel(BaseModel):
         # Use rich.print to create a rich representation of the model
         console = Console()
         with console.capture() as capture:
-            rich.print(self.dict())
+            rich.print(self.model_dump())
         return capture.get()
 
     def open(self) -> str:


### PR DESCRIPTION
# Pull Request

## Changes

Use `self.model_dump()` as recommended.

## Why this change?

Avoid an unnecessary warning message.

## Testing

How was the change tested?

## Additional Notes

Any additional information or context you want to provide?
