### PR TITLE
build: add urls to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,11 @@ packages = [
 ]
 exclude = ["tools/", "tools/**/*"]
 
+[tool.poetry.urls]
+"Homepage" = "https://app.mostly.ai/"
+"Documentation" = "https://mostly-ai.github.io/mostly-python/"
+"Source" = "https://github.com/mostly-ai/mostly-python"
+
 [tool.poetry.dependencies]
 python = "^3.9"
 pydantic = "^2.4.2"


### PR DESCRIPTION
# Pull Request

## Changes

Add URLs to `pyproject.toml`.

## Why this change?

To show Documentation URL on PyPI.

## Testing

How was the change tested?

## Additional Notes

Any additional information or context you want to provide?
