### PR TITLE
feat: support seed or size argument in combination with config

### DIFF
--- a/mostlyai/sdk/client/_utils.py
+++ b/mostlyai/sdk/client/_utils.py
@@ -195,9 +195,9 @@ def harmonize_sd_config(
     else:
         subject_tables = []
 
-    # normalize size, applicable only for the first subject table
+    # normalize size
     if not isinstance(size, dict):
-        size = {table: size for table in subject_tables[:1]}
+        size = {table: size for table in subject_tables}
 
     # normalize seed, applicable only for the first subject table
     if not isinstance(seed, dict):

--- a/mostlyai/sdk/client/_utils.py
+++ b/mostlyai/sdk/client/_utils.py
@@ -195,13 +195,13 @@ def harmonize_sd_config(
     else:
         subject_tables = []
 
-    # normalize size
+    # normalize size, applicable only for the first subject table
     if not isinstance(size, dict):
-        size = {table: size for table in subject_tables}
+        size = {table: size for table in subject_tables[:1]}
 
-    # normalize seed
+    # normalize seed, applicable only for the first subject table
     if not isinstance(seed, dict):
-        seed = {table: seed for table in subject_tables}
+        seed = {table: seed for table in subject_tables[:1]}
 
     # insert name into config
     if name is not None:

--- a/mostlyai/sdk/client/_utils.py
+++ b/mostlyai/sdk/client/_utils.py
@@ -207,16 +207,29 @@ def harmonize_sd_config(
     if name is not None:
         config.name = name
 
+    def size_and_seed_table_configuration(table_name):
+        return SyntheticTableConfiguration(
+            sample_size=size.get(table_name),
+            sample_seed_data=seed.get(table_name) if not isinstance(seed.get(table_name), list) else None,
+            sample_seed_dict=pd.DataFrame(seed.get(table_name)) if isinstance(seed.get(table_name), list) else None,
+        )
+
     # infer tables if not provided
     if not config.tables:
         config.tables = []
         for table in generator.tables:
-            configuration = SyntheticTableConfiguration(
-                sample_size=size.get(table.name),
-                sample_seed_data=seed.get(table.name) if not isinstance(seed.get(table.name), list) else None,
-                sample_seed_dict=pd.DataFrame(seed.get(table.name)) if isinstance(seed.get(table.name), list) else None,
-            )
+            configuration = size_and_seed_table_configuration(table.name)
             config.tables.append(SyntheticTableConfig(name=table.name, configuration=configuration))
+    else:
+        for table in config.tables:
+            configuration = size_and_seed_table_configuration(table.name)
+            table.configuration.sample_size = table.configuration.sample_size or configuration.sample_size
+            table.configuration.sample_seed_data = (
+                table.configuration.sample_seed_data or configuration.sample_seed_data
+            )
+            table.configuration.sample_seed_dict = (
+                table.configuration.sample_seed_dict or configuration.sample_seed_dict
+            )
 
     return config
 

--- a/tests/_local/end_to_end/test_multi_table_with_text.py
+++ b/tests/_local/end_to_end/test_multi_table_with_text.py
@@ -127,7 +127,9 @@ def test_multi_table_with_text(tmp_path):
     assert len(syn["batting"]) == 80
     assert len(syn["fielding"]) == 40
 
-    syn = mostly.probe(g, seed=[{"cat": "a"}])
+    syn = mostly.probe(
+        g, config={"tables": [{"name": "batting", "configuration": {"sampling_temperature": 2}}]}, seed=[{"cat": "a"}]
+    )
     assert syn["players"]["cat"][0] == "a"
     assert len(syn["batting"]) == 4
     assert len(syn["fielding"]) == 2

--- a/tests/_local/end_to_end/test_multi_table_with_text.py
+++ b/tests/_local/end_to_end/test_multi_table_with_text.py
@@ -127,9 +127,7 @@ def test_multi_table_with_text(tmp_path):
     assert len(syn["batting"]) == 80
     assert len(syn["fielding"]) == 40
 
-    syn = mostly.probe(
-        g, config={"tables": [{"name": "batting", "configuration": {"sampling_top_p": 0.95}}]}, seed=[{"cat": "a"}]
-    )
+    syn = mostly.probe(g, seed=[{"cat": "a"}])
     assert syn["players"]["cat"][0] == "a"
     assert len(syn["batting"]) == 4
     assert len(syn["fielding"]) == 2

--- a/tests/_local/end_to_end/test_multi_table_with_text.py
+++ b/tests/_local/end_to_end/test_multi_table_with_text.py
@@ -128,7 +128,7 @@ def test_multi_table_with_text(tmp_path):
     assert len(syn["fielding"]) == 40
 
     syn = mostly.probe(
-        g, config={"tables": [{"name": "batting", "configuration": {"sampling_temperature": 2}}]}, seed=[{"cat": "a"}]
+        g, config={"tables": [{"name": "batting", "configuration": {"sampling_top_p": 0.95}}]}, seed=[{"cat": "a"}]
     )
     assert syn["players"]["cat"][0] == "a"
     assert len(syn["batting"]) == 4

--- a/tests/client/unit/test_utils.py
+++ b/tests/client/unit/test_utils.py
@@ -36,7 +36,7 @@ from mostlyai.sdk.domain import (
     SourceTable,
     SyntheticDatasetConfig,
     SyntheticTableConfig,
-    SyntheticProbeConfig,
+    SyntheticProbeConfig, SourceForeignKey,
 )
 from mostlyai.sdk.client._base_utils import (
     convert_to_base64,
@@ -172,40 +172,107 @@ def simple_sd_config():
     return SyntheticDatasetConfig(tables=[SyntheticTableConfig(name="subject")])
 
 
-def test__harmonize_sd_config(simple_sd_config):
-    mock_get_generator = Mock(
+@pytest.fixture
+def generator_id():
+    return str(uuid.uuid4())
+
+
+@pytest.fixture
+def single_table_generator():
+    return Mock(
         side_effect=lambda id: Generator(
             id=id,
             training_status=ProgressStatus.done,
             metadata=Metadata(),
-            tables=[SourceTable(id=str(uuid.uuid4()), name="table", columns=[])],
+            tables=[SourceTable(id=str(uuid.uuid4()), name="table", columns=[])]
         )
     )
 
-    # case 1: existing config
-    id = str(uuid.uuid4())
-    config = harmonize_sd_config(
-        generator=id,
-        get_generator=mock_get_generator,
-        config=simple_sd_config,
-        config_type=SyntheticDatasetConfig,
+@pytest.fixture
+def multi_table_generator():
+    """Fixture providing a generator with 'subject_1', 'linked_1', and 'subject_2' tables."""
+    return Generator(
+        id=str(uuid.uuid4()),
+        training_status=ProgressStatus.done,
+        metadata=Metadata(),
+        tables=[
+            SourceTable(id=str(uuid.uuid4()), name="subject_1", columns=[]),
+            SourceTable(
+                id=str(uuid.uuid4()),
+                name="linked_1",
+                columns=[],
+                foreign_keys=[SourceForeignKey(
+                    id=str(uuid.uuid4()),
+                    column="subject_1_id",
+                    referenced_table="subject_1",
+                    is_context=True
+                )]
+            ),
+            SourceTable(id=str(uuid.uuid4()), name="subject_2", columns=[])
+        ]
     )
-    assert config == SyntheticDatasetConfig(generator_id=id, tables=[SyntheticTableConfig(name="subject")])
 
-    # case 2: existing config
-    id2 = str(uuid.uuid4())
+def test_harmonize_sd_config_existing_config(generator_id, single_table_generator, simple_sd_config):
     config = harmonize_sd_config(
-        generator=id2,
-        get_generator=mock_get_generator,
+        generator=generator_id,
+        get_generator=single_table_generator,
+        config=simple_sd_config,
+        config_type=SyntheticDatasetConfig
+    )
+
+    expected_config = SyntheticDatasetConfig(generator_id=generator_id, tables=[SyntheticTableConfig(name="subject")])
+    assert config == expected_config
+
+def test_harmonize_sd_no_config(generator_id, single_table_generator):
+    config = harmonize_sd_config(
+        generator=generator_id,
+        get_generator=single_table_generator,
         size=1234,
         seed=pd.DataFrame(),
-        config_type=SyntheticProbeConfig,
+        config_type=SyntheticProbeConfig
     )
+
     assert isinstance(config, SyntheticProbeConfig)
-    assert config.generator_id == id2
+    assert config.generator_id == generator_id
     assert len(config.tables) == 1
+
     table = config.tables[0]
     assert table.name == "table"
     assert table.configuration.sample_size == 1234
     assert table.configuration.sample_seed_data == ANY
     assert table.configuration.sample_seed_dict is None
+
+@pytest.mark.parametrize(
+    "seed, size, config",
+    [
+        (pd.DataFrame(), None, SyntheticProbeConfig()),  # Scenario 1: seed and config provided
+        (None, 1234, SyntheticProbeConfig()),            # Scenario 2: size and config provided
+        (pd.DataFrame(), 1234, SyntheticProbeConfig()),  # Scenario 3: seed, size, and config provided
+    ],
+)
+def test_harmonize_sd_seed_or_size_and_config(multi_table_generator, seed, size, config):
+    """Test harmonization with different combinations of seed, size, and config."""
+    generator_id = str(uuid.uuid4())
+
+    # Mock get_generator to return multi_table_generator
+    mock_get_generator = Mock(return_value=multi_table_generator)
+
+    harmonized_config = harmonize_sd_config(
+        generator=generator_id,
+        get_generator=mock_get_generator,
+        seed=seed,
+        size=size,
+        config=config,
+        config_type=SyntheticProbeConfig,
+    )
+
+    assert isinstance(harmonized_config, SyntheticProbeConfig)
+    assert harmonized_config.generator_id == generator_id
+    assert len(harmonized_config.tables) == len(multi_table_generator.tables)
+
+    seed_b64_or_none = convert_to_base64(seed) if seed is not None else None
+    for table in harmonized_config.tables:
+        assert table.name in ["subject_1", "linked_1", "subject_2"]
+        assert table.configuration.sample_size == (size if table.name == "subject_1" else None)
+        assert table.configuration.sample_seed_data == (seed_b64_or_none if table.name == "subject_1" else None)
+        assert table.configuration.sample_seed_dict is None

--- a/tests/client/unit/test_utils.py
+++ b/tests/client/unit/test_utils.py
@@ -291,6 +291,6 @@ def test_harmonize_sd_seed_or_size_and_config(multi_table_generator, seed, size,
     seed_b64_or_none = convert_to_base64(seed) if seed is not None else None
     for table in harmonized_config.tables:
         assert table.name in ["subject_1", "linked_1", "subject_2"]
-        assert table.configuration.sample_size == (size if table.name == "subject_1" else None)
+        assert table.configuration.sample_size == (size if "subject" in table.name else None)
         assert table.configuration.sample_seed_data == (seed_b64_or_none if table.name == "subject_1" else None)
         assert table.configuration.sample_seed_dict is None

--- a/tests/client/unit/test_utils.py
+++ b/tests/client/unit/test_utils.py
@@ -213,6 +213,23 @@ def multi_table_generator():
     )
 
 
+@pytest.fixture
+def multi_table_synthetic_probe_config():
+    return {
+        "tables": [
+            {
+                "name": "subject_1",
+            },
+            {
+                "name": "linked_1",
+            },
+            {
+                "name": "subject_2",
+            },
+        ]
+    }
+
+
 def test_harmonize_sd_config_existing_config(generator_id, single_table_generator_mock, simple_sd_config):
     config = harmonize_sd_config(
         generator=generator_id,
@@ -246,14 +263,14 @@ def test_harmonize_sd_no_config(generator_id, single_table_generator_mock):
 
 
 @pytest.mark.parametrize(
-    "seed, size, config",
+    "seed, size",
     [
-        (pd.DataFrame(), None, SyntheticProbeConfig()),
-        (None, 1234, SyntheticProbeConfig()),
-        (pd.DataFrame(), 1234, SyntheticProbeConfig()),
+        (pd.DataFrame(), None),
+        (None, 1234),
+        (pd.DataFrame(), 1234),
     ],
 )
-def test_harmonize_sd_seed_or_size_and_config(multi_table_generator, seed, size, config):
+def test_harmonize_sd_seed_or_size_and_config(multi_table_generator, seed, size, multi_table_synthetic_probe_config):
     generator_id = str(uuid.uuid4())
 
     mock_get_generator = Mock(return_value=multi_table_generator)
@@ -263,7 +280,7 @@ def test_harmonize_sd_seed_or_size_and_config(multi_table_generator, seed, size,
         get_generator=mock_get_generator,
         seed=seed,
         size=size,
-        config=config,
+        config=multi_table_synthetic_probe_config,
         config_type=SyntheticProbeConfig,
     )
 

--- a/tests/client/unit/test_utils.py
+++ b/tests/client/unit/test_utils.py
@@ -179,7 +179,7 @@ def generator_id():
 
 
 @pytest.fixture
-def single_table_generator():
+def single_table_generator_mock():
     return Mock(
         side_effect=lambda id: Generator(
             id=id,
@@ -192,7 +192,6 @@ def single_table_generator():
 
 @pytest.fixture
 def multi_table_generator():
-    """Fixture providing a generator with 'subject_1', 'linked_1', and 'subject_2' tables."""
     return Generator(
         id=str(uuid.uuid4()),
         training_status=ProgressStatus.done,
@@ -214,10 +213,10 @@ def multi_table_generator():
     )
 
 
-def test_harmonize_sd_config_existing_config(generator_id, single_table_generator, simple_sd_config):
+def test_harmonize_sd_config_existing_config(generator_id, single_table_generator_mock, simple_sd_config):
     config = harmonize_sd_config(
         generator=generator_id,
-        get_generator=single_table_generator,
+        get_generator=single_table_generator_mock,
         config=simple_sd_config,
         config_type=SyntheticDatasetConfig,
     )
@@ -226,10 +225,10 @@ def test_harmonize_sd_config_existing_config(generator_id, single_table_generato
     assert config == expected_config
 
 
-def test_harmonize_sd_no_config(generator_id, single_table_generator):
+def test_harmonize_sd_no_config(generator_id, single_table_generator_mock):
     config = harmonize_sd_config(
         generator=generator_id,
-        get_generator=single_table_generator,
+        get_generator=single_table_generator_mock,
         size=1234,
         seed=pd.DataFrame(),
         config_type=SyntheticProbeConfig,
@@ -249,16 +248,14 @@ def test_harmonize_sd_no_config(generator_id, single_table_generator):
 @pytest.mark.parametrize(
     "seed, size, config",
     [
-        (pd.DataFrame(), None, SyntheticProbeConfig()),  # Scenario 1: seed and config provided
-        (None, 1234, SyntheticProbeConfig()),  # Scenario 2: size and config provided
-        (pd.DataFrame(), 1234, SyntheticProbeConfig()),  # Scenario 3: seed, size, and config provided
+        (pd.DataFrame(), None, SyntheticProbeConfig()),
+        (None, 1234, SyntheticProbeConfig()),
+        (pd.DataFrame(), 1234, SyntheticProbeConfig()),
     ],
 )
 def test_harmonize_sd_seed_or_size_and_config(multi_table_generator, seed, size, config):
-    """Test harmonization with different combinations of seed, size, and config."""
     generator_id = str(uuid.uuid4())
 
-    # Mock get_generator to return multi_table_generator
     mock_get_generator = Mock(return_value=multi_table_generator)
 
     harmonized_config = harmonize_sd_config(

--- a/tests/client/unit/test_utils.py
+++ b/tests/client/unit/test_utils.py
@@ -36,7 +36,8 @@ from mostlyai.sdk.domain import (
     SourceTable,
     SyntheticDatasetConfig,
     SyntheticTableConfig,
-    SyntheticProbeConfig, SourceForeignKey,
+    SyntheticProbeConfig,
+    SourceForeignKey,
 )
 from mostlyai.sdk.client._base_utils import (
     convert_to_base64,
@@ -184,9 +185,10 @@ def single_table_generator():
             id=id,
             training_status=ProgressStatus.done,
             metadata=Metadata(),
-            tables=[SourceTable(id=str(uuid.uuid4()), name="table", columns=[])]
+            tables=[SourceTable(id=str(uuid.uuid4()), name="table", columns=[])],
         )
     )
+
 
 @pytest.fixture
 def multi_table_generator():
@@ -201,27 +203,28 @@ def multi_table_generator():
                 id=str(uuid.uuid4()),
                 name="linked_1",
                 columns=[],
-                foreign_keys=[SourceForeignKey(
-                    id=str(uuid.uuid4()),
-                    column="subject_1_id",
-                    referenced_table="subject_1",
-                    is_context=True
-                )]
+                foreign_keys=[
+                    SourceForeignKey(
+                        id=str(uuid.uuid4()), column="subject_1_id", referenced_table="subject_1", is_context=True
+                    )
+                ],
             ),
-            SourceTable(id=str(uuid.uuid4()), name="subject_2", columns=[])
-        ]
+            SourceTable(id=str(uuid.uuid4()), name="subject_2", columns=[]),
+        ],
     )
+
 
 def test_harmonize_sd_config_existing_config(generator_id, single_table_generator, simple_sd_config):
     config = harmonize_sd_config(
         generator=generator_id,
         get_generator=single_table_generator,
         config=simple_sd_config,
-        config_type=SyntheticDatasetConfig
+        config_type=SyntheticDatasetConfig,
     )
 
     expected_config = SyntheticDatasetConfig(generator_id=generator_id, tables=[SyntheticTableConfig(name="subject")])
     assert config == expected_config
+
 
 def test_harmonize_sd_no_config(generator_id, single_table_generator):
     config = harmonize_sd_config(
@@ -229,7 +232,7 @@ def test_harmonize_sd_no_config(generator_id, single_table_generator):
         get_generator=single_table_generator,
         size=1234,
         seed=pd.DataFrame(),
-        config_type=SyntheticProbeConfig
+        config_type=SyntheticProbeConfig,
     )
 
     assert isinstance(config, SyntheticProbeConfig)
@@ -242,11 +245,12 @@ def test_harmonize_sd_no_config(generator_id, single_table_generator):
     assert table.configuration.sample_seed_data == ANY
     assert table.configuration.sample_seed_dict is None
 
+
 @pytest.mark.parametrize(
     "seed, size, config",
     [
         (pd.DataFrame(), None, SyntheticProbeConfig()),  # Scenario 1: seed and config provided
-        (None, 1234, SyntheticProbeConfig()),            # Scenario 2: size and config provided
+        (None, 1234, SyntheticProbeConfig()),  # Scenario 2: size and config provided
         (pd.DataFrame(), 1234, SyntheticProbeConfig()),  # Scenario 3: seed, size, and config provided
     ],
 )


### PR DESCRIPTION
```python
# seed applicable to the first subject table, size applicable to all subject tables
sd = mostly.generate(generator=g, config=sd_config, seed=df, size=100)
```