### PR TITLE
fix: train a generator providing a config with data as uri

### DIFF
--- a/mostlyai/sdk/domain.py
+++ b/mostlyai/sdk/domain.py
@@ -25,7 +25,7 @@ from pydantic import field_validator, model_validator
 import uuid
 import rich
 import zipfile
-from mostlyai.sdk.client._base_utils import convert_to_base64
+from mostlyai.sdk.client._base_utils import convert_to_base64, read_table_from_path
 from typing import Any, ClassVar, Literal, Annotated
 
 from mostlyai.sdk.client.base import CustomBaseModel
@@ -2106,6 +2106,9 @@ class SourceTableConfig(CustomBaseModel):
     @field_validator("data", mode="before")
     @classmethod
     def convert_data_before(cls, value):
+        # an empty (pd.DataFrame()) parquet in base64 is 800 chars. Assuming a shorter str is a URI
+        if isinstance(value, Path) or (isinstance(value, str) and len(value) < 512):
+            _, value = read_table_from_path(value)
         return (
             convert_to_base64(value)
             if isinstance(value, pd.DataFrame)

--- a/tests/_local/end_to_end/test_simple_flat.py
+++ b/tests/_local/end_to_end/test_simple_flat.py
@@ -73,6 +73,16 @@ def test_simple_flat(tmp_path, encoding_types):
     assert g.name == "Test 1"
     g.delete()
 
+    # config via dict and sugar
+    g = mostly.train(config={
+        'tables': [{
+            'name': 'data',
+            'data': 'https://github.com/mostly-ai/public-demo-data/raw/refs/heads/dev/census/census.csv.gz'
+        }]
+    }, start=False
+    )
+    g.delete()
+
     # config via class
     g = mostly.train(config=GeneratorConfig(**config), start=False)
     assert g.name == "Test 1"

--- a/tests/_local/end_to_end/test_simple_flat.py
+++ b/tests/_local/end_to_end/test_simple_flat.py
@@ -74,12 +74,16 @@ def test_simple_flat(tmp_path, encoding_types):
     g.delete()
 
     # config via dict and sugar
-    g = mostly.train(config={
-        'tables': [{
-            'name': 'data',
-            'data': 'https://github.com/mostly-ai/public-demo-data/raw/refs/heads/dev/census/census.csv.gz'
-        }]
-    }, start=False
+    g = mostly.train(
+        config={
+            "tables": [
+                {
+                    "name": "data",
+                    "data": "https://github.com/mostly-ai/public-demo-data/raw/refs/heads/dev/census/census.csv.gz",
+                }
+            ]
+        },
+        start=False,
     )
     g.delete()
 


### PR DESCRIPTION
Support cases such as:
```python
    g = mostly.train(
        config={
            "tables": [
                {
                    "name": "data",
                    "data": "https://github.com/mostly-ai/public-demo-data/raw/refs/heads/dev/census/census.csv.gz",
                }
            ]
        },
        start=False,
    )
```