### PR TITLE
fix: replace the colon in the directory names with underscore

### DIFF
--- a/mostlyai/sdk/_local/synthetic_datasets.py
+++ b/mostlyai/sdk/_local/synthetic_datasets.py
@@ -131,7 +131,7 @@ def create_synthetic_dataset(
                         task_type=TaskType.generate_tabular
                         if model_type == ModelType.tabular
                         else TaskType.generate_language,
-                        model_label=f"{table.name}:{model_type.value.lower()}",
+                        model_label=f"{table.name}_{model_type.value.lower()}",
                         step_code=step,
                         progress=ProgressValue(value=0, max=1),
                         status=ProgressStatus.new,


### PR DESCRIPTION
# Pull Request

## Changes

replaced the colon in the directory names with an underscore to be able to run on Windows.

## Why this change?

Windows folder names can't contain colons

## Testing

I couldn't run the unit test as they depend on Unix Domain Sockets, and I use an older version of Windows 10. 

## Additional Notes

I think you need to modify the unit tests to include a specific port explicitly to avoid this situation. better still, you could remove the UDS completely and replace it with a default port option.
