### PR TITLE
misc: update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,7 @@ gen-public-model: ## build pydantic models for public api
 	datamodel-codegen --url $(PUBLIC_API_FULL_URL) $(COMMON_OPTIONS)
 	#datamodel-codegen --input ../mostly-app-v2/public-api/public-api.yaml $(COMMON_OPTIONS)
 	python tools/postproc_domain.py
-	uv run --no-sync ruff format .
-	uv run --no-sync ruff check . --fix
+	uv run --no-sync pre-commit run --all-files
 
 # Common options for both targets
 COMMON_OPTIONS = \


### PR DESCRIPTION
run pre-commit hooks instead of only ruff after auto generation of public API model
so that it will also re-add the license and use syntax of python >=3.10 for `domain.py`