### PR TITLE
fix: sanitize pd.DataFrame for pyarrow compatability

### DIFF
--- a/mostlyai/sdk/_local/connectors.py
+++ b/mostlyai/sdk/_local/connectors.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import uuid
 from pathlib import Path
 from io import BytesIO
 import pandas as pd
@@ -117,6 +117,8 @@ def query_data_from_connector(connector: Connector, sql: str) -> pd.DataFrame:
 
     try:
         data_container = create_container_from_connector(connector)
-        return data_container.query(sql)
+        df = data_container.query(sql)
+        # sanitize for pyarrow
+        return df.applymap(lambda x: str(x) if isinstance(x, uuid.UUID) else x)
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e))


### PR DESCRIPTION
# Pull Request

## Changes

Sanitization of `pd.DataFrame` instance during `query` and `write_data` to stay compatible with `pyarrow` backend.

## Why this change?

[Bug](https://github.com/mostly-ai/mostlyai/issues/455) fix.

## Testing

Tested on a PostgreSQL DB with several uneasy `dtypes` for `pyarrow`.

## Additional Notes

`read_data` was also tested, and is not affected.