### PR TITLE
fix: cache regions for s3fs to work properly across regions

### DIFF
--- a/mostlyai/sdk/_data/file/container/aws.py
+++ b/mostlyai/sdk/_data/file/container/aws.py
@@ -92,6 +92,7 @@ class AwsS3FileContainer(BucketBasedContainer):
                 secret=self.secret_key,
                 key=self.access_key,
                 client_kwargs=client_kwargs,
+                cache_regions=True,
             )
             self._boto_resource = boto_session.resource("s3", endpoint_url=self.endpoint_url, verify=self.ssl_verify)
             self._boto_client = boto_session.client("s3", endpoint_url=self.endpoint_url, verify=self.ssl_verify)


### PR DESCRIPTION
# Pull Request

## Changes

Make an AWS S3 connector work, supporting buckets from more than a single region.

## Why this change?

`S3FileSystem` with `cache_regions=True` will simply instantiate a client for each region on request.

## Testing

How was the change tested?

## Additional Notes

Any additional information or context you want to provide?
