### PR TITLE
fix: rstrip dot from db-based prefix in list_locations

### DIFF
--- a/mostlyai/sdk/_data/db/base.py
+++ b/mostlyai/sdk/_data/db/base.py
@@ -739,6 +739,7 @@ class SqlAlchemyContainer(DBContainer, abc.ABC):
             self.update_dbschema(None)
             return sorted(list(set(self.all_schemas())))
         else:
+            prefix = prefix.rstrip(".")  # remove trailing dot if present
             # List the tables of the provided schema named {prefix}
             self.update_dbschema(prefix)
             locations = [".".join([prefix, loc]) for loc in self.get_object_list()]


### PR DESCRIPTION
Remove trailing `.` if present from prefix in list_locations for database-based connectors.

For example:

`table_locations = c.locations('public.')` would now also work. Alongside, the currently expected "no trailing dot" convention, as in `table_locations = c.locations('public')`.