### PR TITLE
fix bug in multi-table tutorial; fixes #589

### DIFF
--- a/docs/tutorials/multi-table/multi-table.ipynb
+++ b/docs/tutorials/multi-table/multi-table.ipynb
@@ -122,6 +122,7 @@
     "            \"data\": originals[\"transaction\"],\n",
     "            \"primary_key\": \"trans_id\",\n",
     "            \"foreign_keys\": [{\"column\": \"account_id\", \"referenced_table\": \"account\", \"is_context\": True}],\n",
+    "            \"tabular_model_configuration\": {\"max_training_time\": 5},  # limit training to 5 mins\n",
     "        },\n",
     "        {\n",
     "            \"name\": \"loan\",\n",
@@ -155,8 +156,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# open generator in a new browser tab\n",
-    "g.open()"
+    "# open generator in a new browser tab (only for CLIENT mode)\n",
+    "if not mostly.local:\n",
+    "    g.open()"
    ]
   },
   {
@@ -180,8 +182,10 @@
    },
    "outputs": [],
    "source": [
+    "# start training\n",
     "g.training.start()\n",
-    "g = g.training.wait(progress_bar=True)"
+    "# wait until done\n",
+    "g.training.wait(progress_bar=True)"
    ]
   },
   {
@@ -203,7 +207,10 @@
    "source": [
     "# generate a synthetic dataset\n",
     "sd = mostly.generate(g, size={\"account\": 4500, \"client\": 5369}, start=False)\n",
-    "sd.open()"
+    "\n",
+    "# open synthetic dataset in a new browser tab (only for CLIENT mode)\n",
+    "if not mostly.local:\n",
+    "    sd.open()"
    ]
   },
   {
@@ -214,8 +221,10 @@
    },
    "outputs": [],
    "source": [
+    "# start generation\n",
     "sd.generation.start()\n",
-    "sd = sd.generation.wait(progress_bar=True)"
+    "# wait until done\n",
+    "sd.generation.wait(progress_bar=True)"
    ]
   },
   {

--- a/docs/tutorials/multi-table/multi-table.ipynb
+++ b/docs/tutorials/multi-table/multi-table.ipynb
@@ -295,41 +295,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import matplotlib.pyplot as plt\n",
-    "\n",
-    "# Convert the 'date' column to datetime format for the third dataframe\n",
-    "originals[\"transaction\"][\"date\"] = pd.to_datetime(originals[\"transaction\"][\"date\"])\n",
-    "synthetics[\"transaction\"][\"date\"] = pd.to_datetime(synthetics[\"transaction\"][\"date\"])\n",
-    "\n",
-    "# Create the side-by-side scatter plots\n",
-    "fig, axes = plt.subplots(nrows=1, ncols=2, figsize=(18, 6), sharey=True)\n",
-    "\n",
-    "# Plot original data\n",
-    "axes[0].scatter(originals[\"transaction\"][\"date\"], originals[\"transaction\"][\"amount\"], s=1, alpha=0.5)\n",
-    "axes[0].set_title(\"Amount vs Date (Original)\")\n",
-    "axes[0].set_xlabel(\"Date\")\n",
-    "axes[0].set_ylabel(\"Amount\")\n",
-    "axes[0].grid(True)\n",
-    "\n",
-    "# Plot synthetic data\n",
-    "axes[1].scatter(synthetics[\"transaction\"][\"date\"], synthetics[\"transaction\"][\"amount\"], s=1, alpha=0.5)\n",
-    "axes[1].set_title(\"Amount vs Date (MOSTLY AI)\")\n",
-    "axes[1].set_xlabel(\"Date\")\n",
-    "axes[1].grid(True)\n",
-    "\n",
-    "# Adjust layout\n",
-    "plt.tight_layout()\n",
-    "\n",
-    "# show\n",
-    "plt.show()"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {
     "tags": []


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Make UI opens client-only, cap transaction model training to 5 minutes, adjust start/wait usage, and remove the plotting section.
> 
> - **Tutorial notebook (`docs/tutorials/multi-table/multi-table.ipynb`)**:
>   - **Configuration**: Add `tabular_model_configuration: {"max_training_time": 5}` to `transaction` table.
>   - **Client vs Local**: Guard `g.open()` and `sd.open()` with `if not mostly.local`.
>   - **Execution Flow**: Separate `start()` and `wait()` calls for training and generation (no reassignment from `wait`).
>   - **Cleanup**: Remove matplotlib scatter plot visualization cell.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c63ee45e3395ab89e44a59d9120cce5ae1bcba19. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->