### PR TITLE
fix typos in docs

### DIFF
--- a/docs/tutorials/conditional-generation/conditional-generation.ipynb
+++ b/docs/tutorials/conditional-generation/conditional-generation.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "# Flexible Conditional Simulation <a href=\"https://colab.research.google.com/github/mostly-ai/mostlyai/blob/main/docs/tutorials/conditional-generation/conditional-generation.ipynb\" target=\"_blank\"><img src=\"https://img.shields.io/badge/Open%20in-Colab-blue?logo=google-colab\" alt=\"Run on Colab\"></a>\n",
     "\n",
-    "In this tutorial, we show how to generate samples that are conditioned on specific values for a set of attributes. By that, we effectively create partially synthetic data, where synthetic attributes are randomly sampled given the context of a handful of pre-determined fixed attributes. Note, that the synthetic data is still statistically representative, but within the given context. The privacy of the overall dataset is then largely dependend on the privacy of the provided fixed attributes.\n",
+    "In this tutorial, we show how to generate samples that are conditioned on specific values for a set of attributes. By that, we effectively create partially synthetic data, where synthetic attributes are randomly sampled given the context of a handful of pre-determined fixed attributes. Note, that the synthetic data is still statistically representative, but within the given context. The privacy of the overall dataset is then largely dependent on the privacy of the provided fixed attributes.\n",
     "\n",
     "We will demonstrate conditional simulation for two use cases:\n",
     "1. First, we generate synthetic data for the UCI Adult Income, but will probe the model for a specific combination of attributes. We will then study the remaining attributes and perform ad-hoc What-If analysis.\n",
@@ -364,7 +364,7 @@
     "%%capture --no-display\n",
     "\n",
     "\n",
-    "def plot_manhatten(df, title):\n",
+    "def plot_manhattan(df, title):\n",
     "    ax = df_orig.plot.scatter(\n",
     "        x=\"longitude\",\n",
     "        y=\"latitude\",\n",
@@ -378,8 +378,8 @@
     "    plt.show()\n",
     "\n",
     "\n",
-    "plot_manhatten(df_orig, \"Original Data\")\n",
-    "plot_manhatten(syn_partial, \"Partially Synthetic Data\")"
+    "plot_manhattan(df_orig, \"Original Data\")\n",
+    "plot_manhattan(syn_partial, \"Partially Synthetic Data\")"
    ]
   },
   {
@@ -397,7 +397,7 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "In this tutorial we walked throught the process of conditional simulation to yield partially synthetic data. This allows you to probe the generative model with a specific context, whether that is hypothetical (use case 1) or real (use case 2), and gain corresponding insights for specific scenarios.\n",
+    "In this tutorial we walked through the process of conditional simulation to yield partially synthetic data. This allows you to probe the generative model with a specific context, whether that is hypothetical (use case 1) or real (use case 2), and gain corresponding insights for specific scenarios.\n",
     "\n",
     "## Further exercises\n",
     "\n",

--- a/docs/tutorials/explainable-ai/explainable-ai.ipynb
+++ b/docs/tutorials/explainable-ai/explainable-ai.ipynb
@@ -513,7 +513,7 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "This tutorial demonstrated how ML models, that have been trained on real data, can be safely tested and explained with synthetic data. As the latter is not privacy-sensitive, this allows to have these types of introspections and validations performed by a significantly larger group of stakeholders. This is a key part to build safe & smart algorithms, that will have a significant impact on individuals' lives."
+    "This tutorial demonstrated how ML models, that have been trained on real data, can be safely tested and explained with synthetic data. As the latter is not privacy-sensitive, this allows to have these types of introspection and validations performed by a significantly larger group of stakeholders. This is a key part to build safe & smart algorithms, that will have a significant impact on individuals' lives."
    ]
   },
   {

--- a/docs/tutorials/fairness/fairness.ipynb
+++ b/docs/tutorials/fairness/fairness.ipynb
@@ -229,7 +229,7 @@
    "id": "10381448",
    "metadata": {},
    "source": [
-    "Statistical parity difference is mitigated for the fair synthetic dataset, i.e. the proportion of females and mals with high income is comparable."
+    "Statistical parity difference is mitigated for the fair synthetic dataset, i.e. the proportion of females and males with high income is comparable."
    ]
   },
   {

--- a/docs/tutorials/getting-started/getting-started.ipynb
+++ b/docs/tutorials/getting-started/getting-started.ipynb
@@ -5,7 +5,7 @@
    "id": "9adc1d85-0da1-495e-8e83-d1fadfd59d18",
    "metadata": {},
    "source": [
-    "# Getting Started with the SDK  <a href=\"https://colab.research.google.com/github/mostly-ai/mostlyai/blob/main/docs/tutorials/quick-start/quick-start.ipynb\" target=\"_blank\"><img src=\"https://img.shields.io/badge/Open%20in-Colab-blue?logo=google-colab\" alt=\"Run on Colab\"></a>\n",
+    "# Getting Started with the SDK  <a href=\"https://colab.research.google.com/github/mostly-ai/mostlyai/blob/main/docs/tutorials/getting-started/getting-started.ipynb\" target=\"_blank\"><img src=\"https://img.shields.io/badge/Open%20in-Colab-blue?logo=google-colab\" alt=\"Run on Colab\"></a>\n",
     "\n",
     "In this notebook, we take our first steps with the SDK by training a basic single-table generator, to then probe it for new synthetic samples.\n",
     "\n",

--- a/docs/tutorials/multi-table/multi-table.ipynb
+++ b/docs/tutorials/multi-table/multi-table.ipynb
@@ -77,7 +77,7 @@
    "source": [
     "## Train a multi-table generator\n",
     "\n",
-    "Configuring a mutli-table generator is simply done, by configuring each table, their primary key as well as all their foreign key relations.\n",
+    "Configuring a multi-table generator is simply done, by configuring each table, their primary key as well as all their foreign key relations.\n",
     "\n",
     "As can be seen from the entity relationship diagram above, the Berka dataset has two privacy-sensitive tables, that do not reference any other privacy-sensitive table. These two top-level tables (\"client\" and \"account\") will act as our subject tables, that are independently generated. All other tables are linked to these, and thus will also then be generated in their context.\n",
     "\n",

--- a/docs/tutorials/size-vs-accuracy/size-vs-accuracy.ipynb
+++ b/docs/tutorials/size-vs-accuracy/size-vs-accuracy.ipynb
@@ -471,7 +471,7 @@
     "\n",
     "For the given dataset and the given synthesizer we can indeed observe an increase in synthetic data quality with a growing number of training samples. This can be measured with respect to accuracy, as well as ML utility.\n",
     "\n",
-    "As we can also observe, is that a holdout dataset will exhibit deviations from the training data due to the sampling noise as well. With the holdout data being actual data, that hasn't been seen before, it serves us as a north star in terms of maximum acchievable accuracy for synthetic data. See our paper on this subject [[2](#refs)].\n",
+    "As we can also observe, is that a holdout dataset will exhibit deviations from the training data due to the sampling noise as well. With the holdout data being actual data, that hasn't been seen before, it serves us as a north star in terms of maximum achievable accuracy for synthetic data. See our paper on this subject [[2](#refs)].\n",
     "\n",
     "## Further exercises\n",
     "\n",

--- a/docs/tutorials/smart-imputation/smart-imputation.ipynb
+++ b/docs/tutorials/smart-imputation/smart-imputation.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "Dealing with datasets that contain missing values can be a challenge. This is especially so if the remaining non-missing values are not representative and thus provide a distorted, biased picture of the overall population.\n",
     "\n",
-    "In this tutorial we demonstrate how MOSTLY AI can help to close such gaps in your data via \"Smart Imputation\". By generating a synthetic dataset that doest not contain any missing values, it is possible to create a complete and sound representation of the underlying population. With this smartly imputed synthetic dataset it is then straightforward to accurately analyze the population as if all values were present in the first place.\n",
+    "In this tutorial we demonstrate how MOSTLY AI can help to close such gaps in your data via \"Smart Imputation\". By generating a synthetic dataset that does not contain any missing values, it is possible to create a complete and sound representation of the underlying population. With this smartly imputed synthetic dataset it is then straightforward to accurately analyze the population as if all values were present in the first place.\n",
     "\n",
     "For this tutorial, we will be using a modified version of the UCI Adult Income dataset, that itself stems from the 1994 American Community Survey by the US census bureau. This reduced dataset consists of 48,842 records and 10 mixed-type features. We will replace ~30% of the values for attribute `age` with missing values. We will do this randomly, but with a specified bias, so that we end up missing the age information particularly from the elder segments."
    ]

--- a/docs/tutorials/synthetic-text-lstm/synthetic-text-lstm.ipynb
+++ b/docs/tutorials/synthetic-text-lstm/synthetic-text-lstm.ipynb
@@ -487,7 +487,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can see that correlations between Term occurence and the price per night, are also very well retained."
+    "We can see that correlations between Term occurrence and the price per night, are also very well retained."
    ]
   },
   {
@@ -498,9 +498,9 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "This tutorial demonstrated how synthetic text can be generated wihtin the context of an otherwise structured dataset. We analyzed the generated texts, and validated that characters and terms occur with the same frequency, while exact matches do not occur anymore likely than within the actual text itself.\n",
+    "This tutorial demonstrated how synthetic text can be generated within the context of an otherwise structured dataset. We analyzed the generated texts, and validated that characters and terms occur with the same frequency, while exact matches do not occur anymore likely than within the actual text itself.\n",
     "\n",
-    "This feature thus allows to retain valuable statistical insights, typically burried away in free text columns, that remain inaccessible due to their privacy sensitive nature."
+    "This feature thus allows to retain valuable statistical insights, typically buried away in free text columns, that remain inaccessible due to their privacy sensitive nature."
    ]
   },
   {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fixes numerous typos/grammar and updates a Colab link across tutorial notebooks, including renaming `plot_manhatten` to `plot_manhattan`.
> 
> - **Docs (tutorial notebooks)**:
>   - **Spelling/grammar fixes** across `conditional-generation`, `explainable-ai`, `fairness`, `size-vs-accuracy`, `smart-imputation`, `synthetic-text-lstm` (e.g., `dependent`, `walked through`, `introspection`, `males`, `achievable`, `does not`, `occurrence`, `within`, `buried`).
>   - **Function rename**: `plot_manhatten` -> `plot_manhattan` and updated calls in `conditional-generation`.
>   - **Link update**: Correct Colab badge URL in `getting-started/getting-started.ipynb`.
>   - **Typo fix**: `mutli-table` -> `multi-table` in `multi-table` tutorial.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b008f2ed3b6bf13d0a7142a20e7ae421318795de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->