### PR TITLE
docs: fix typos in docstrings

### DIFF
--- a/mostlyai/sdk/_data/db/base.py
+++ b/mostlyai/sdk/_data/db/base.py
@@ -862,7 +862,7 @@ def use_ssh_tunnel(
 class SqlAlchemyTable(DBTable, abc.ABC):
     ENABLE_ORDER_AND_LIMIT_ON_SQL: bool = True
     IS_SERVER_SIDE_CURSOR_AVAILABLE: bool = True
-    SA_RANDOM: sa.sql.Executable | None = None  # must be overriden
+    SA_RANDOM: sa.sql.Executable | None = None  # must be overridden
     SA_MAX_VALS_PER_BATCH: int = 10_000
     SA_MAX_VALS_PER_IN_CLAUSE: int | None = None
     SA_CONN_DIALECT_PROPS: dict[str, Any] | None = None

--- a/mostlyai/sdk/_data/dtype.py
+++ b/mostlyai/sdk/_data/dtype.py
@@ -75,7 +75,7 @@ class DType(abc.ABC):
 
     def coerce(self, data: pd.Series) -> pd.Series:
         """
-        Coerce a given the data to self's data type (expected to be overriden for each specific coercion)
+        Coerce a given the data to self's data type (expected to be overridden for each specific coercion).
         :param data: data
         :return: coerced pd.Series of data
         """
@@ -108,7 +108,7 @@ class DType(abc.ABC):
             return False  # in case of a failure, be on the safer side
 
     def get_encompass_data_fallback_dtypes(self) -> list["DType"]:
-        """Returns a default list of fallback dtypes for data encompassment (shall be overriden, when needed)"""
+        """Returns a default list of fallback dtypes for data encompassment (shall be overridden, when needed)."""
         return [VirtualVarchar]
 
     def encompass_data(

--- a/mostlyai/sdk/_data/non_context.py
+++ b/mostlyai/sdk/_data/non_context.py
@@ -30,7 +30,7 @@ def handle_non_context_relations(
     data: pd.DataFrame,
     is_target: bool,
 ) -> pd.DataFrame:
-    """Handle all non-context relations for a table"""
+    """Handle all non-context relations for a table."""
     non_context_relations = schema.subset(
         relation_type=NonContextRelation,
         relations_to=[table_name],

--- a/mostlyai/sdk/_data/pull_utils.py
+++ b/mostlyai/sdk/_data/pull_utils.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Data pull."""
+"""Data pull utilities."""
 
 import itertools
 import json
@@ -655,7 +655,7 @@ def export_chunk(
     data_dir: Path,
     do_ctx_only: bool,
 ):
-    """Distributes rows of a chunk into partitions using hash trick"""
+    """Distributes rows of a chunk into partitions using hash trick."""
 
     data_dir.mkdir(exist_ok=True, parents=True)
 
@@ -701,7 +701,7 @@ def export_chunk(
 
 
 def consolidate_partitions(data_dir: Path, shuffle: bool = True):
-    """Consolidates partition chunks into partitions"""
+    """Consolidates partition chunks into partitions."""
     t0 = time.time()
     for partition_dir in sorted(d for d in data_dir.glob("part.*/") if d.is_dir()):
         partition_data = pd.concat(

--- a/tests/_data/unit/test_non_context.py
+++ b/tests/_data/unit/test_non_context.py
@@ -25,7 +25,7 @@ from mostlyai.sdk._data.non_context import (
 
 
 def test_handle_non_context_relation(tmp_path):
-    """Test single non-context relation with missing and broken links"""
+    """Test single non-context relation with missing and broken links."""
     data = pd.DataFrame(
         {
             "id": [1, 2, 3, 4, 5],
@@ -63,7 +63,7 @@ def test_handle_non_context_relation(tmp_path):
 
 
 def test_handle_non_context_relations(tmp_path):
-    """Test multiple non-context relations"""
+    """Test multiple non-context relations."""
     # prepare data
     non_ctx_path = tmp_path / "non_ctx.parquet"
     pd.DataFrame(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fixes typos and punctuation in docstrings/module descriptions across data, DB, and test modules.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 11d4f03d60cd813a553ca18393d6221340a49586. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->