### PR TITLE
fix: consider quiet=True also for SDK initialization

### DIFF
--- a/mostlyai/sdk/client/api.py
+++ b/mostlyai/sdk/client/api.py
@@ -209,6 +209,10 @@ class MostlyAI(_MostlyBaseClient):
         else:
             raise ValueError("Invalid SDK mode")
 
+        # Set quiet mode BEFORE any rich output
+        if quiet:
+            rich.get_console().quiet = True
+
         client_kwargs = {
             "base_url": base_url,
             "api_key": api_key,
@@ -253,9 +257,6 @@ class MostlyAI(_MostlyBaseClient):
                 rich.print(f"Failed to connect to {self.base_url} : {e}.")
         else:
             raise ValueError("Invalid SDK mode")
-
-        if quiet:
-            rich.get_console().quiet = True
 
     def __repr__(self) -> str:
         if self.local:


### PR DESCRIPTION
# Pull Request

## Changes

Moved the `rich.get_console().quiet = True` statement to ensure `quiet` mode is activated before any initialization messages are printed. Removed the duplicate `quiet` setting.

## Why this change?

The `quiet` parameter in `MostlyAI` was not correctly implemented. Initialization messages were printed *before* `quiet` mode was set, causing them to appear even when `quiet=True` was passed. This change ensures `quiet` mode is active from the start of the `MostlyAI` instance initialization.

## Testing

The fix was verified by:
- Creating a temporary test script to confirm that initialization messages are now suppressed when `quiet=True`.
- Confirming that necessary interactive prompts (e.g., for credentials) are still displayed, as they are intentionally not suppressed by `quiet=True`.
- Relying on existing test suites (`tests/_local/unit/test_server.py` and `tests/_local/end_to_end/test_simple_flat.py`) which use `quiet=True`.

## Additional Notes

Interactive prompts (e.g., for user credentials) are intentionally not suppressed by `quiet=True` as they are critical for user interaction. This change specifically addresses the suppression of initial SDK setup messages.

---
<a href="https://cursor.com/background-agent?bcId=bc-cf31ea89-fd8f-4d95-a600-ebd0fed81ee5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cf31ea89-fd8f-4d95-a600-ebd0fed81ee5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

