### PR TITLE
fix: treat empty columns as categorical instead of datetime

### DIFF
--- a/mostlyai/sdk/_data/auto_detect.py
+++ b/mostlyai/sdk/_data/auto_detect.py
@@ -84,6 +84,10 @@ def auto_detect_encoding_type(x: pd.Series):
     x = x.astype(str)
     x = x[x.str.strip() != ""]  # filter out empty and whitespace-only strings
 
+    # if all values are null or empty, default to categorical
+    if len(x) == 0:
+        return ModelEncodingType.tabular_categorical
+
     # if all non-null values can be converted to datetime -> datetime encoding
     if safe_convert_datetime(x).notna().all():
         return ModelEncodingType.tabular_datetime

--- a/tests/_data/unit/test_auto_detect.py
+++ b/tests/_data/unit/test_auto_detect.py
@@ -85,6 +85,21 @@ class TestAutoDetectEncodingType:
         series = pd.Series(values)
         assert auto_detect_encoding_type(series) == ModelEncodingType.tabular_categorical
 
+    @pytest.mark.parametrize(
+        "values",
+        [
+            [None] * 100,  # all null values
+            [""] * 100,  # all empty strings
+            ["   "] * 100,  # all whitespace-only strings
+            [None, "", "   "] * 33,  # mix of null, empty, and whitespace
+            [None, "", "   ", "  \t  ", "  \n  "] * 20,  # mix with different whitespace
+        ],
+    )
+    def test_all_null_or_empty(self, values):
+        series = pd.Series(values)
+        # When all values are null or empty, default to tabular_categorical
+        assert auto_detect_encoding_type(series) == ModelEncodingType.tabular_categorical
+
 
 @pytest.fixture
 def data_table(tmp_path):


### PR DESCRIPTION
# Pull Request

## Changes

Briefly describe your changes here.

## Why this change?

Explain the reason for the change.

## Testing

How was the change tested?

## Additional Notes

Any additional information or context you want to provide?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Auto-detect now returns tabular_categorical for all-null/empty/whitespace-only columns, with tests added for these cases.
> 
> - **Auto-detect logic (`mostlyai/sdk/_data/auto_detect.py`)**:
>   - Return `ModelEncodingType.tabular_categorical` when a column is all null/empty/whitespace after cleaning.
> - **Tests (`tests/_data/unit/test_auto_detect.py`)**:
>   - Add parametrized tests validating all-null/empty/whitespace-only inputs default to `tabular_categorical`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32c0d771ae9cc72fe8272fc506c60fe1cd7d6022. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->