### PR TITLE
fix(hive): avoid engine disposal for hive + session contextualized

### DIFF
--- a/mostlyai/sdk/_data/db/hive.py
+++ b/mostlyai/sdk/_data/db/hive.py
@@ -172,6 +172,10 @@ class HiveContainer(SqlAlchemyContainer):
     def table_class(cls):
         return HiveTable
 
+    def use_sa_engine(self, mode="read_data", dispose=False):
+        # always keep the engine alive to reuse the cached connection
+        return super().use_sa_engine(mode=mode, dispose=dispose)
+
     def does_database_exist(self) -> bool:
         with self.init_sa_connection("db_exist_check") as connection:
             result = connection.execute(sa.text("SHOW DATABASES"))


### PR DESCRIPTION
- Fix Hive by preventing its engine disposal. That makes the reuse of its cached connection work as intended.
- Slight refactor in `read_chunks_by_scan` to handle session using a context manager