### PR TITLE
fix: extra seed without foreign key

### DIFF
--- a/mostlyai/sdk/_local/execution/step_generate_data.py
+++ b/mostlyai/sdk/_local/execution/step_generate_data.py
@@ -102,7 +102,7 @@ def execute_step_generate_data(
             extra_seed_dir.mkdir(parents=True, exist_ok=True)
 
             extra_seed_data = sample_seed[extra_columns].copy()
-            context_fk = next((fk for fk in tgt_g_table.foreign_keys if fk.is_context), None)
+            context_fk = next((fk for fk in (tgt_g_table.foreign_keys or []) if fk.is_context), None)
             if context_fk and context_fk.column in sample_seed.columns:
                 # for sequential tables, save context key + row index to align seed data after sequence completion
                 extra_seed_data[context_fk.column] = sample_seed[context_fk.column].astype("string[pyarrow]")

--- a/tests/_local/end_to_end/test_simple_flat.py
+++ b/tests/_local/end_to_end/test_simple_flat.py
@@ -193,9 +193,6 @@ def test_simple_flat(tmp_path, mostly, encoding_types):
     df = mostly.probe(g, size=10)
     assert len(df) == 10
 
-    df = mostly.probe(g, seed=pd.DataFrame({"a": ["a1"], "x": ["x"]}))
-    assert df[["a", "x"]].values.tolist() == [["a1", "x"]]
-
     df = mostly.probe(g, seed=pd.DataFrame({"a": ["a1"] * 10}))
     assert len(df) == 10
 
@@ -213,6 +210,12 @@ def test_simple_flat(tmp_path, mostly, encoding_types):
     sd_config = sd.config()
     assert isinstance(sd_config, SyntheticDatasetConfig)
     assert sd_config.tables[0].configuration.sample_size == 100
+    sd.delete()
+
+    # with (extra) seed
+    sd = mostly.generate(g, seed=pd.DataFrame({"a": ["a1"], "x": ["x"]}))
+    sd_data = sd.data()
+    assert sd_data[["a", "x"]].values.tolist() == [["a1", "x"]]
     sd.delete()
 
     # config via class

--- a/tests/_local/end_to_end/test_simple_flat.py
+++ b/tests/_local/end_to_end/test_simple_flat.py
@@ -193,6 +193,10 @@ def test_simple_flat(tmp_path, mostly, encoding_types):
     df = mostly.probe(g, size=10)
     assert len(df) == 10
 
+    df = mostly.probe(g, seed=pd.DataFrame({"a": ["a1"], "x": ["x"]}))
+    assert len(df) == 1
+    # assert df[["a", "x"]].values.tolist() == [["a1", "x"]] # TODO: activate this once staging is updated
+
     df = mostly.probe(g, seed=pd.DataFrame({"a": ["a1"] * 10}))
     assert len(df) == 10
 
@@ -210,12 +214,6 @@ def test_simple_flat(tmp_path, mostly, encoding_types):
     sd_config = sd.config()
     assert isinstance(sd_config, SyntheticDatasetConfig)
     assert sd_config.tables[0].configuration.sample_size == 100
-    sd.delete()
-
-    # with (extra) seed
-    sd = mostly.generate(g, seed=pd.DataFrame({"a": ["a1"], "x": ["x"]}))
-    sd_data = sd.data()
-    assert sd_data[["a", "x"]].values.tolist() == [["a1", "x"]]
     sd.delete()
 
     # config via class

--- a/tests/_local/end_to_end/test_simple_flat.py
+++ b/tests/_local/end_to_end/test_simple_flat.py
@@ -193,6 +193,9 @@ def test_simple_flat(tmp_path, mostly, encoding_types):
     df = mostly.probe(g, size=10)
     assert len(df) == 10
 
+    df = mostly.probe(g, seed=pd.DataFrame({"a": ["a1"], "x": ["x"]}))
+    assert df[["a", "x"]].values.tolist() == [["a1", "x"]]
+
     df = mostly.probe(g, seed=pd.DataFrame({"a": ["a1"] * 10}))
     assert len(df) == 10
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Handle missing foreign keys during extra seed extraction and add an E2E probe test for seeds with extra columns.
> 
> - **Fix (local generation)**:
>   - Safely handle missing `foreign_keys` by iterating over `(tgt_g_table.foreign_keys or [])` when extracting context FK for extra seed columns in `mostlyai/sdk/_local/execution/step_generate_data.py`.
> - **Tests**:
>   - Extend end-to-end test to probe with seed containing extra columns (e.g., `{"a": ["a1"], "x": ["x"]}`) in `tests/_local/end_to_end/test_simple_flat.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 655c63bef9497916ba7563444e68c0a5f2f582f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->