### PR TITLE
feat: update TABULAR_CHARACTER detection logic

### DIFF
--- a/mostlyai/sdk/_data/auto_detect.py
+++ b/mostlyai/sdk/_data/auto_detect.py
@@ -98,7 +98,9 @@ def auto_detect_encoding_type(x: pd.Series) -> ModelEncodingType:
 
     # if more than 5% of rows contain unique values
     if len(x) >= 100 and x.value_counts().eq(1).reindex(x).mean() > 0.05:
-        if x.str.len().nunique() == 1:  # if all values are of the same length -> character encoding
+        if (
+            x.str.len().nunique() == 1 or x.str.len().max() <= 36
+        ):  # if all values are of the same length or shorter than 36 chars -> character encoding
             return ModelEncodingType.tabular_character
         else:  # if values are of different lengths -> text encoding
             return ModelEncodingType.language_text

--- a/tests/_data/unit/test_auto_detect.py
+++ b/tests/_data/unit/test_auto_detect.py
@@ -32,6 +32,7 @@ class TestAutoDetectEncodingType:
         "values",
         [
             [str(uuid.uuid4()) for _ in range(100)],  # 100 unique values of same length
+            [f"string{i}" for i in range(100)],  # 100 values of variable lengths shorter than 36 chars
         ],
     )
     def test_tabular_character(self, values):
@@ -41,7 +42,8 @@ class TestAutoDetectEncodingType:
     @pytest.mark.parametrize(
         "values",
         [
-            [str(uuid.uuid4()) for _ in range(20)] + ["cat1", "cat2"] * 90,  # 20 out of 200 are unique > 0.05
+            [str(uuid.uuid4()) * 2 for _ in range(20)]
+            + ["cat1", "cat2"] * 90,  # 20 out of 200 are unique > 0.05 and some longer than 36 chars
         ],
     )
     def test_language_text(self, values):
@@ -121,7 +123,8 @@ def data_table(tmp_path):
     int_column = list(range(num_rows))
     float_column = [i * 0.1 for i in range(num_rows)]
     lat_long_column = ["48.20849, 16.37208"] * num_rows
-    str_column = [f"string_{i}" for i in range(num_rows)]
+    char_column = ["string" + str(i) for i in range(num_rows)]
+    text_column = ["string" + str(i) * 10 for i in range(num_rows)]
 
     pd.DataFrame(
         {
@@ -129,8 +132,8 @@ def data_table(tmp_path):
             "int": int_column,
             "float": float_column,
             "lat_long": lat_long_column,
-            "str": str_column,
-            "id": str_column,
+            "str": text_column,
+            "id": char_column,
         }
     ).to_parquet(pqt_path)
 


### PR DESCRIPTION
When there are enough amount of unique strings but all of them are shorter than 36 chars, detect the column as `TABULAR_CHARACTER` instead of `LANGUAGE_TEXT`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Columns with enough unique strings of max length 36 are now classified as `tabular_character`; tests and fixtures updated accordingly.
> 
> - **Auto-detect logic (`mostlyai/sdk/_data/auto_detect.py`)**:
>   - Classify columns with >5% unique values as `tabular_character` if all strings are same length or their max length is <= `36`; otherwise `language_text`.
> - **Tests (`tests/_data/unit/test_auto_detect.py`)**:
>   - Add case asserting variable-length strings under 36 chars map to `tabular_character`.
>   - Adjust `language_text` case to include strings >36 chars.
>   - Update parquet fixture: separate `id` (short char-like) and `str` (long text-like) columns; expectations updated for datetime, lat/long, text, and PK detection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 604b52ef68066c357bc4654bbca94527de9079e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->