### PR TITLE
build(github): update workflow step references to use commit sha 

### DIFF
--- a/.github/workflows/build-docker-image.yaml
+++ b/.github/workflows/build-docker-image.yaml
@@ -16,31 +16,31 @@ jobs:
       id-token: write
     steps:
       - name: Setup | Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with: {fetch-depth: 1}
 
       - name: Setup | Docker Buildx
-        uses: docker/setup-buildx-action@v3.10.0
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
         with:
           cache-binary: false
           cleanup: false
           platforms: ${{ env.PLATFORMS }}
 
       - name: Setup | Docker Build Metadata
-        uses: docker/metadata-action@v5.7.0
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v.5.10.0
         id: meta
         with:
           images: ghcr.io/mostly-ai/sdk
 
       - name: Setup | Docker Login
-        uses: docker/login-action@v3.4.0
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build | Build Docker Image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 #v6.18.0
         env:
           BUILDX_NO_DEFAULT_ATTESTATIONS: '1'
           DOCKER_BUILD_SUMMARY: 'false'

--- a/.github/workflows/pre-commit-check.yaml
+++ b/.github/workflows/pre-commit-check.yaml
@@ -1,24 +1,24 @@
-name: "mostlyai Pre-Commit Check"
+name: 'mostlyai Pre-Commit Check'
 
 on: [workflow_call]
 
 env:
-    PYTHON_KEYRING_BACKEND: keyring.backends.null.Keyring
-    FORCE_COLOR: "1"
+  PYTHON_KEYRING_BACKEND: keyring.backends.null.Keyring
+  FORCE_COLOR: '1'
 
 jobs:
-    pre-commit-check:
-        runs-on: ubuntu-latest
-        steps:
-          - uses: actions/checkout@v4
-          - name: Set up Python
-            uses: actions/setup-python@v5
-            with:
-              python-version: '3.10'
-          - name: Install dependencies
-            run: |
-              python -m pip install --upgrade pip
-              pip install pre-commit
-              pre-commit install
-          - name: Run pre-commit
-            run: pre-commit run --all-files
+  pre-commit-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - name: Set up Python
+        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pre-commit
+          pre-commit install
+      - name: Run pre-commit
+        run: pre-commit run --all-files

--- a/.github/workflows/run-tests-cpu.yaml
+++ b/.github/workflows/run-tests-cpu.yaml
@@ -14,13 +14,13 @@ jobs:
       packages: write
     steps:
       - name: Setup | Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 1
           submodules: 'true'
 
       - name: Setup | uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@ed21f2f24f8dd64503750218de024bcf64c7250a # v7.1.5
         with:
           enable-cache: false
           python-version: '3.10'
@@ -49,13 +49,13 @@ jobs:
       packages: write
     steps:
       - name: Setup | Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 1
           submodules: 'true'
 
       - name: Setup | uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@ed21f2f24f8dd64503750218de024bcf64c7250a # v7.1.5
         with:
           enable-cache: false
           python-version: '3.10'

--- a/.github/workflows/run-tests-gpu.yaml
+++ b/.github/workflows/run-tests-gpu.yaml
@@ -1,10 +1,10 @@
-name: "[GPU] mostlyai Tests"
+name: '[GPU] mostlyai Tests'
 
 on: [workflow_call]
 
 env:
   PYTHON_KEYRING_BACKEND: keyring.backends.null.Keyring
-  FORCE_COLOR: "1"
+  FORCE_COLOR: '1'
 
 jobs:
   run-test-gpu:
@@ -25,16 +25,16 @@ jobs:
           apt-get install -y --no-install-recommends git tzdata build-essential
 
       - name: Setup | Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 1
-          submodules: "true"
+          submodules: 'true'
 
       - name: Setup | uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@ed21f2f24f8dd64503750218de024bcf64c7250a # v7.1.5
         with:
           enable-cache: false
-          python-version: "3.10"
+          python-version: '3.10'
 
       - name: Setup | Dependencies
         run: |


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Pins Actions to commit SHAs and upgrades versions across CI workflows, with minor YAML normalization.
> 
> - **CI Workflows**:
>   - **Pin and upgrade Actions**:
>     - `actions/checkout` → `@8e8c483...` (v6.0.1) in `build-docker-image`, `pre-commit-check`, `run-tests-{cpu,gpu}`.
>     - `docker/setup-buildx-action` → `@e468171...` (v3.11.1), `docker/metadata-action` → `@c299e40...` (v5.10.0), `docker/login-action` → `@5e57cd1...` (v3.6.0), `docker/build-push-action` → `@2634353...` (v6.18.0) in `build-docker-image`.
>     - `actions/setup-python` → `@83679a8...` (v6.1.0) in `pre-commit-check`.
>     - `astral-sh/setup-uv` → `@ed21f2f...` (v7.1.5) in `run-tests-{cpu,gpu}`.
>   - **YAML cleanup**:
>     - Normalize quoting and `name` fields; consistent `submodules: 'true'` and `FORCE_COLOR: '1'`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fdaf8eaba6ee305f64bf1e0f0d569033ace3b214. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->