### PR TITLE
chore: fix licensing year and adjust use-current-year option in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       name: Generate temporary license header file
       entry: |
         bash -c '
-        HEADER_CONTENT="Copyright 2024 MOSTLY AI\n\
+        HEADER_CONTENT="Copyright 2025 MOSTLY AI\n\
         \n\
         Licensed under the Apache License, Version 2.0 (the \"License\");\n\
         you may not use this file except in compliance with the License.\n\

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
         # - --remove-header
         - --license-filepath
         - LICENSE_HEADER
-        - --use-current-year
+        # - --use-current-year
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v5.0.0
   hooks:

--- a/mostlyai/sdk/__init__.py
+++ b/mostlyai/sdk/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mostlyai/sdk/_local/__init__.py
+++ b/mostlyai/sdk/_local/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mostlyai/sdk/_local/execution/__init__.py
+++ b/mostlyai/sdk/_local/execution/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mostlyai/sdk/_local/execution/step_analyze_training_data.py
+++ b/mostlyai/sdk/_local/execution/step_analyze_training_data.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mostlyai/sdk/_local/execution/step_create_data_report.py
+++ b/mostlyai/sdk/_local/execution/step_create_data_report.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mostlyai/sdk/_local/execution/step_create_model_report.py
+++ b/mostlyai/sdk/_local/execution/step_create_model_report.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mostlyai/sdk/_local/execution/step_deliver_data.py
+++ b/mostlyai/sdk/_local/execution/step_deliver_data.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mostlyai/sdk/_local/execution/step_encode_training_data.py
+++ b/mostlyai/sdk/_local/execution/step_encode_training_data.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mostlyai/sdk/_local/execution/step_finalize_generation.py
+++ b/mostlyai/sdk/_local/execution/step_finalize_generation.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mostlyai/sdk/_local/execution/step_finalize_training.py
+++ b/mostlyai/sdk/_local/execution/step_finalize_training.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mostlyai/sdk/_local/execution/step_generate_data.py
+++ b/mostlyai/sdk/_local/execution/step_generate_data.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mostlyai/sdk/_local/execution/step_generate_model_report_data.py
+++ b/mostlyai/sdk/_local/execution/step_generate_model_report_data.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mostlyai/sdk/_local/execution/step_pull_training_data.py
+++ b/mostlyai/sdk/_local/execution/step_pull_training_data.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mostlyai/sdk/_local/execution/step_train_model.py
+++ b/mostlyai/sdk/_local/execution/step_train_model.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mostlyai/sdk/client/__init__.py
+++ b/mostlyai/sdk/client/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mostlyai/sdk/client/_base_utils.py
+++ b/mostlyai/sdk/client/_base_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mostlyai/sdk/client/_naming_conventions.py
+++ b/mostlyai/sdk/client/_naming_conventions.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mostlyai/sdk/client/_utils.py
+++ b/mostlyai/sdk/client/_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mostlyai/sdk/client/api.py
+++ b/mostlyai/sdk/client/api.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mostlyai/sdk/client/base.py
+++ b/mostlyai/sdk/client/base.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mostlyai/sdk/client/connectors.py
+++ b/mostlyai/sdk/client/connectors.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mostlyai/sdk/client/exceptions.py
+++ b/mostlyai/sdk/client/exceptions.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mostlyai/sdk/client/generators.py
+++ b/mostlyai/sdk/client/generators.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mostlyai/sdk/client/integrations.py
+++ b/mostlyai/sdk/client/integrations.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mostlyai/sdk/client/synthetic_datasets.py
+++ b/mostlyai/sdk/client/synthetic_datasets.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/_local/end_to_end/test_connector.py
+++ b/tests/_local/end_to_end/test_connector.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/_local/end_to_end/test_multi_table_with_text.py
+++ b/tests/_local/end_to_end/test_multi_table_with_text.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/_local/end_to_end/test_simple_flat.py
+++ b/tests/_local/end_to_end/test_simple_flat.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/client/__init__.py
+++ b/tests/client/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/client/unit/__init__.py
+++ b/tests/client/unit/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/client/unit/test_base.py
+++ b/tests/client/unit/test_base.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/client/unit/test_naming_conventions.py
+++ b/tests/client/unit/test_naming_conventions.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/client/unit/test_utils.py
+++ b/tests/client/unit/test_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/extend_model.py
+++ b/tools/extend_model.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/model.py
+++ b/tools/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/postproc_domain.py
+++ b/tools/postproc_domain.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Standardizes license headers to 2025 and aligns pre-commit license insertion settings.
> 
> - Updates license headers across SDK, tests, and tools to `2025`
> - Adjusts `.pre-commit-config.yaml`: generates 2025 header content and comments out `--use-current-year` for `insert-license`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d4e33ae5b3b97e0ed43db1a1d40251814beaca46. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->