### PR TITLE
fix: pandas 3 compatibility

### DIFF
--- a/mostlyai/sdk/_data/context.py
+++ b/mostlyai/sdk/_data/context.py
@@ -137,9 +137,9 @@ def _shuffle_groups(df: pd.DataFrame, root_key: str) -> pd.DataFrame:
     # Shuffle the index
     shuffled_df = df.sample(frac=1).reset_index(drop=True)
     # Sorting by group_order within each group
-    shuffled_df.sort_values(by=[group_order], inplace=True)
+    shuffled_df = shuffled_df.sort_values(by=[group_order])
     # Remove the temporary group_order column
-    shuffled_df.drop(columns=group_order, inplace=True)
+    shuffled_df = shuffled_df.drop(columns=group_order)
     return shuffled_df
 
 

--- a/mostlyai/sdk/_data/dtype.py
+++ b/mostlyai/sdk/_data/dtype.py
@@ -310,6 +310,10 @@ def coerce_dtype_by_encoding(
         x = pd.to_datetime(x, errors="coerce", utc=True)
         # currently we do not retain timezone info
         x = x.dt.tz_localize(None)
+        # clamp out-of-bounds values before ns downcast (pandas 3 returns us resolution)
+        _min = pd.Timestamp.min.tz_localize(None)
+        _max = pd.Timestamp.max.tz_localize(None)
+        x = x.where(x.between(_min, _max), other=pd.NaT)
         # convert to timestamp with ns resolution
         x = x.astype("datetime64[ns]")
     elif encoding_type in [
@@ -396,6 +400,10 @@ def datetime_coerce(s: pd.Series) -> pd.Series:
     n_coerced = n_na_1 - n_na_0
     if n_coerced > 0:
         _LOG.warning(f"{n_coerced} values coerced during datetime_coerce")
+    # clamp out-of-bounds values before ns downcast (pandas 3 returns us resolution)
+    _min = pd.Timestamp.min.tz_localize(None)
+    _max = pd.Timestamp.max.tz_localize(None)
+    s = s.where(s.between(_min, _max), other=pd.NaT)
     # map to "datetime64[ns]"
     return s.astype("datetime64[ns]")
 

--- a/mostlyai/sdk/_data/non_context.py
+++ b/mostlyai/sdk/_data/non_context.py
@@ -164,7 +164,7 @@ def add_is_null_for_non_context_relation(
 
     # replace the fk column with the is_null values and rename it accordingly
     data[fk] = is_null_values
-    data.rename(columns={fk: relation.get_is_null_column(is_target=is_target)}, inplace=True)
+    data = data.rename(columns={fk: relation.get_is_null_column(is_target=is_target)})
 
     return data
 

--- a/mostlyai/sdk/_data/util/kerberos.py
+++ b/mostlyai/sdk/_data/util/kerberos.py
@@ -61,7 +61,7 @@ def is_kerberos_ticket_alive(klist_result: str, service_principal: str):
     df["expires"] = expires.apply(safe_parse)
 
     # Drop rows where date parsing failed
-    df.dropna(subset=["issued", "expires"], inplace=True)
+    df = df.dropna(subset=["issued", "expires"])
 
     # Check if the principal's ticket has not expired
     now = datetime.now()

--- a/mostlyai/sdk/_local/execution/step_finalize_generation.py
+++ b/mostlyai/sdk/_local/execution/step_finalize_generation.py
@@ -147,9 +147,8 @@ def postprocess_temp_columns(df: pd.DataFrame, table_name: str, schema: Schema):
         for col in temp_columns:
             df[col] = df[col].apply(lambda x: f"mostly{str(uuid.uuid4())[6:]}" if x == "False" else pd.NA)
         # remove suffix
-        df.rename(
+        df = df.rename(
             columns={c: c.removesuffix(suffix) for c in temp_columns},
-            inplace=True,
         )
 
     return df


### PR DESCRIPTION
## Summary
- **Fixes #704**: Clamp out-of-bounds datetime values to `NaT` before `datetime64[ns]` downcast in `coerce_dtype_by_encoding()` and `datetime_coerce()`. Pandas 3 returns microsecond resolution from `pd.to_datetime()`, which can hold dates outside the nanosecond range (e.g., year 0001), causing `OutOfBoundsDatetime` on the subsequent `[ns]` cast.
- **Proactive fix**: Remove all `inplace=True` usage across SDK modules (`context.py`, `non_context.py`, `step_finalize_generation.py`, `kerberos.py`), as pandas 3 removed the `inplace` parameter from many DataFrame methods.
- **Note on #703**: The `drop(columns=..., axis=1)` bug is in `mostlyai-engine` v2.4.0, not this repo — requires a separate engine release.

## Test plan
- [x] Unit tests pass (`pytest tests/_data/unit/ tests/_local/unit/ tests/test_domain.py` — 349 passed)
- [ ] Verify with pandas 3 installed
- [ ] Verify backward compatibility with pandas 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)