### PR TITLE
ci: upgrade GitHub Actions Python from 3.10 to 3.11

### DIFF
--- a/.github/workflows/pre-commit-check.yaml
+++ b/.github/workflows/pre-commit-check.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/run-tests-cpu.yaml
+++ b/.github/workflows/run-tests-cpu.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: astral-sh/setup-uv@ed21f2f24f8dd64503750218de024bcf64c7250a # v7.1.5
         with:
           enable-cache: false
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Setup | Dependencies
         run: |
@@ -58,7 +58,7 @@ jobs:
         uses: astral-sh/setup-uv@ed21f2f24f8dd64503750218de024bcf64c7250a # v7.1.5
         with:
           enable-cache: false
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Setup | Dependencies
         run: |

--- a/.github/workflows/run-tests-gpu.yaml
+++ b/.github/workflows/run-tests-gpu.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: astral-sh/setup-uv@ed21f2f24f8dd64503750218de024bcf64c7250a # v7.1.5
         with:
           enable-cache: false
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Setup | Dependencies
         run: |


### PR DESCRIPTION
## Summary
- Upgrades Python version from 3.10 to 3.11 across all GitHub Actions workflows (`run-tests-cpu`, `run-tests-gpu`, `pre-commit-check`)

## Test plan
- [ ] Verify CPU tests pass with Python 3.11
- [ ] Verify GPU tests pass with Python 3.11
- [ ] Verify pre-commit checks pass with Python 3.11

🤖 Generated with [Claude Code](https://claude.com/claude-code)