### PR TITLE
fix(pull): preserve ctx_key column when per-group sampling under pandas 3.0

### DIFF
--- a/mostlyai/sdk/_data/pull_utils.py
+++ b/mostlyai/sdk/_data/pull_utils.py
@@ -473,14 +473,14 @@ def fetch_table_data(
             key_fraction_df["n_rows"] = int_part + (random_draws < frac_part).astype(int)
 
             ctx_key = key_fraction_df.columns[0]
+            # shuffle, then keep the first n rows per ctx_key group via cumcount; this preserves
+            # the grouping column in the output across pandas versions (pandas 3.0 drops the
+            # grouping column from groupby().apply() results by default)
             chunk_df = chunk_df.sample(frac=1)
-
-            def sample_n_rows(group):
-                n = key_fraction_df.loc[key_fraction_df[ctx_key] == group.name, "n_rows"].values[0]
-                return group.sample(n=min(n, len(group)))  # don't exceed available rows
-
-            # group by ctx_key and apply the sampling function
-            chunk_df = chunk_df.groupby(ctx_key, group_keys=False).apply(sample_n_rows).reset_index(drop=True)
+            n_per_group = key_fraction_df.set_index(ctx_key)["n_rows"]
+            cumcount = chunk_df.groupby(ctx_key).cumcount()
+            limit = chunk_df[ctx_key].map(n_per_group).fillna(0).astype(int)
+            chunk_df = chunk_df.loc[cumcount < limit].reset_index(drop=True)
 
             _LOG.info(f"drop {chunk_size - len(chunk_df)} ctx_keys to protect privacy")
         if sample_fraction is not None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Pull Request

## Changes

Replace the `DataFrame.groupby(ctx_key, group_keys=False).apply(sample_n_rows)` based per-group sampling in `fetch_table_data` (`mostlyai/sdk/_data/pull_utils.py`) with a shuffle + `cumcount` + per-row limit. This keeps the grouping column in the fetched chunk and works identically on pandas 2.x and 3.0.

## Why this change?

### CI failure on #708

On PR #708 (`chore/update-engine-2.5.0-qa-1.10.4-github`) the `run-tests-cpu / run-test-cpu-local` job hit the 6 hour workflow timeout. The hang happened inside `tests/_local/end_to_end/test_multi_table_with_text.py::test_multi_table_with_text`, and the training subprocess it spawned was crashing on `KeyError: 'players_id'` at:

```
mostlyai/sdk/_data/pull_utils.py:868: in _hash_column
    return chunk[key]
```

Parent process never observed the crash, so it sat waiting on the generator forever.

### Root cause

The PR bumps the `mostlyai-engine` / `mostlyai-qa` extras to direct git refs (2.5.0 / 1.10.4) which only require `pandas>=2.2.0` / `numpy>=2.0.0`. The CI installs `.[local]` without the lockfile (`uv sync --frozen --only-group dev` installs only dev deps; `uv pip install ... ".[local]" ...` then resolves fresh), so on the feature branch CI picks up pandas 3.0.2 / numpy 2.4.3 / pyarrow 24.0.0 — whereas `main` stays on the locked pandas 2.2.3. The test passes locally with pandas 2.2.3 and reproducibly hangs with pandas 3.0.2.

Pandas 3.0 removed the `include_groups=True` default behavior of `DataFrame.groupby(col).apply(func)`: the grouping column is no longer part of the group passed into `func` and is not in the result. In `fetch_table_data`, `sample_n_rows` receives a group and returns `group.sample(n=...)`, so with pandas 3.0 the grouping column (`ctx_key`, here `players_id`) is dropped from every chunk that goes through the `key_fraction_df` path. That chunk is then written to the fetched parquet and read back during `split_target`, where `_hash_column` tries to look up `chunk[ctx_key]` and raises.

### Fix

Instead of using `groupby().apply()` whose shape depends on pandas version, shuffle the chunk, compute a per-row `cumcount` grouped by `ctx_key`, and keep only rows where the cumcount is below the per-group limit derived from `key_fraction_df["n_rows"]`. The sampling semantics (shuffle + keep n per group) are preserved; the grouping column is preserved; behavior is identical on pandas 2.x and 3.0.

## Testing

With CI-style install (`pandas==3.0.2`, `numpy==2.4.3`, `pyarrow==24.0.0`, engine 2.5.0 from git, qa 1.10.4 from git):

- `pytest -vv tests/_local/end_to_end -k 'not (client and mode)'` → 9 passed, 2 deselected
- `pytest -vv tests/_local/end_to_end/test_multi_table_with_text.py` → 1 passed in ~66s

Without the fix, the same env hangs on `test_multi_table_with_text`.

The unrelated pre-existing failures in `tests/_data/unit/test_dtype.py` (`NaT` vs `<NA>`, `VirtualInteger` vs `VirtualFloat`) and `tests/_data/unit/test_finalize_generation.py` / `tests/_data/unit/test_push.py` reproduce on the base branch as well and are not caused or affected by this change.

## Additional Notes

This is a targeted fix for PR #708 and should be merged into that branch (or the bump can be redone on top of `main`); either way the underlying pandas-3.0 incompatibility in `fetch_table_data` is a real latent bug that will surface as soon as the lockfile is refreshed, so it is worth fixing independently.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-04efc525-3f84-4320-8797-9c35a07ddfc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04efc525-3f84-4320-8797-9c35a07ddfc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

