### PR TITLE
docs: add CLAUDE.md with high-leverage debugging notes for AI agents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,9 @@
+# CLAUDE.md
+
+Notes for AI coding agents working on this repo. Keep it short; add things here only when they would have saved real debugging time.
+
+- **Local-mode training/generation runs in a subprocess; crashes are silent.** If a test hangs or a generator stays `in_progress`, the child process (`mostlyai/sdk/_local/cli.py`, spawned from `mostlyai/sdk/_local/routes.py`) has almost certainly died. Read `<home_dir>/generators/<id>/job.log` (or `<home_dir>/synthetic-datasets/<id>/job.log`) for the real traceback — it will not surface in pytest output.
+
+- **CI does NOT install `[local]` / `[local-gpu]` from `uv.lock`.** `run-tests-cpu.yaml` / `run-tests-gpu.yaml` do `uv sync --frozen --only-group dev` then `uv pip install ".[local]" ...`, which re-resolves engine/qa/pandas/numpy/pyarrow fresh. `CONTRIBUTING.md` (`uv sync --frozen --extra local`) gives a different, locked set. To reproduce a CI-only failure locally, run CI's exact install sequence.
+
+- **Watch for pandas 3.0 breakage in `mostlyai/sdk/_data/`.** `DataFrame.groupby(col).apply(func)` no longer includes the grouping column in `func`'s input or the result, and `include_groups` is gone. Grep `\.groupby\(.*\)\.apply\(` before bumping deps; in the pull pipeline any silent column drop there surfaces much later as a `KeyError` in `pull_utils.py::_hash_column` inside the training subprocess.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Pull Request

## Changes

Adds a short `CLAUDE.md` at the repo root with three bullets capturing the things that cost the most time while debugging the CPU CI hang on #708:

1. Local-mode training/generation runs in a subprocess, and its crashes are silent — always read `job.log`.
2. CI does not install `[local]` / `[local-gpu]` from `uv.lock`, so "works locally" and "works in CI" can diverge on upstream deps.
3. Pandas 3.0 `groupby().apply()` no longer includes the grouping column — a recurring footgun in the pull pipeline.

## Why this change?

These were all non-obvious failure modes that an agent (or human) hitting them for the first time would have to rediscover. Keeping the file intentionally tiny so it stays useful and doesn't drift.

## Testing

N/A — docs only.

## Additional Notes

If the team already uses a different convention (e.g. `AGENTS.md`, `.cursor/rules`), happy to move/rename.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-04efc525-3f84-4320-8797-9c35a07ddfc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04efc525-3f84-4320-8797-9c35a07ddfc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

