### PR TITLE
fix: make _data code and unit tests pandas-3 compatible

### DIFF
--- a/mostlyai/sdk/_data/dtype.py
+++ b/mostlyai/sdk/_data/dtype.py
@@ -184,6 +184,16 @@ class VirtualBoolean(VirtualDType):
         return bool_coerce(data)
 
 
+def _to_numeric_or_same(data: pd.Series, downcast: str) -> pd.Series:
+    # pandas 3.0 dropped errors="ignore" for pd.to_numeric; emulate the
+    # previous "return input unchanged on failure" contract that our cast()
+    # callers relied on.
+    try:
+        return pd.to_numeric(data, errors="raise", downcast=downcast, dtype_backend="pyarrow")
+    except (ValueError, TypeError):
+        return data
+
+
 class VirtualInteger(VirtualDType):
     def get_encompass_data_fallback_dtypes(self) -> list["DType"]:
         return [VirtualFloat, VirtualVarchar]
@@ -192,7 +202,7 @@ class VirtualInteger(VirtualDType):
         return int_coerce(data)
 
     def cast(self, data: pd.Series) -> pd.Series:
-        return pd.to_numeric(data, errors="ignore", downcast="integer", dtype_backend="pyarrow")
+        return _to_numeric_or_same(data, downcast="integer")
 
 
 class VirtualFloat(VirtualDType):
@@ -200,7 +210,7 @@ class VirtualFloat(VirtualDType):
         return float_coerce(data)
 
     def cast(self, data: pd.Series) -> pd.Series:
-        return pd.to_numeric(data, errors="ignore", downcast="float", dtype_backend="pyarrow")
+        return _to_numeric_or_same(data, downcast="float")
 
 
 class VirtualDate(VirtualDType):
@@ -468,8 +478,11 @@ def time_coerce(s: pd.Series) -> pd.Series:
     n_coerced = n_na_1 - n_na_0
     if n_coerced > 0:
         _LOG.warning(f"{n_coerced} values coerced during datetime_coerce")
-    # map to "object"
-    return s.astype("object")
+    # map to "object", and normalize pd.NaT to pd.NA so the result is uniform
+    # regardless of whether any row survived coercion (pandas 3 is stricter
+    # about distinguishing NaT vs NA under the object dtype)
+    s = s.astype("object")
+    return s.where(~s.isna(), pd.NA)
 
 
 class PandasDType(WrappedDType):

--- a/mostlyai/sdk/_data/file/table/json.py
+++ b/mostlyai/sdk/_data/file/table/json.py
@@ -125,13 +125,17 @@ class JsonDataTable(FileDataTable):
             if is_date_dtype(df[c]):
                 df[c] = df[c].dt.strftime("%Y-%m-%d")
             elif is_timestamp_dtype(df[c]):
-                # we need to strip off any milliseconds
+                # we need to strip off any microseconds (pyarrow-backed
+                # timestamps include them in strftime output regardless of
+                # format string; use str.slice rather than str[:-7] because
+                # pandas 3.0 removed StringMethods.__getitem__ for pyarrow
+                # extension arrays)
                 df[c] = (
                     df[c]
                     .dt.tz_localize(None)
                     .astype("timestamp[us][pyarrow]")
                     .dt.strftime("%Y-%m-%d %H:%M:%S")
-                    .str[:-7]
+                    .str.slice(stop=-7)
                 )
         mode = self.handle_if_exists(if_exists)
         df.to_json(self.container.path_str, orient="records", lines=True, mode=mode)

--- a/tests/_data/unit/test_finalize_generation.py
+++ b/tests/_data/unit/test_finalize_generation.py
@@ -48,8 +48,10 @@ def test_finalize_table_generation(tmp_path, tgt_data):
     gen_data = tgt_table.read_data()
     gen_data_path = tmp_path / "gen"
     gen_data_path.mkdir(exist_ok=True, parents=True)
-    # make 3 partitions
-    get_data_partitioned = np.array_split(gen_data, 3)
+    # make 3 partitions (np.array_split returns ndarrays for DataFrames on
+    # numpy 2 / pandas 3, so split via positional indices to keep DataFrames)
+    split_points = np.array_split(np.arange(len(gen_data)), 3)
+    get_data_partitioned = [gen_data.iloc[idx] for idx in split_points]
     # save each part into a separate parquet file
     for i, df_part in enumerate(get_data_partitioned):
         part_fn = gen_data_path / f"part.{i:06}.parquet"
@@ -103,7 +105,7 @@ def test_export_data_to_excel(tmp_path):
     excel_file_path = tmp_path / "synthetic-samples.xlsx"
     xls = pd.ExcelFile(excel_file_path)
 
-    expected_values = pd.DataFrame({"A": [0, 1, 2, 3, 4, 5, 6, 7, 8], "X": ["x"] * 9, "N": [None] * 9})
+    expected_values = pd.DataFrame({"A": [0, 1, 2, 3, 4, 5, 6, 7, 8], "X": ["x"] * 9})
     # Iterate over each sheet
     for sheet_name in xls.sheet_names:
         df = pd.read_excel(xls, sheet_name=sheet_name)
@@ -115,7 +117,11 @@ def test_export_data_to_excel(tmp_path):
             # Check the expected values
             df.sort_values(by="A", ascending=True, inplace=True)
             df.reset_index(drop=True, inplace=True)
-            pd.testing.assert_frame_equal(df, expected_values, check_dtype=False)
+            # the "N" column is all-missing; compare via isna() to stay
+            # agnostic of how read_excel materializes nulls (NaN vs None vs NA)
+            # across pandas versions
+            assert df["N"].isna().all()
+            pd.testing.assert_frame_equal(df.drop(columns=["N"]), expected_values, check_dtype=False)
 
     # Check for the sheet names
     expected_sheets = ["_TOC_", "A", "B", "C"]

--- a/tests/_data/unit/test_push.py
+++ b/tests/_data/unit/test_push.py
@@ -55,7 +55,10 @@ def source_table_partitioned(tmp_path):
     source_data_path = tmp_path / "source"
     source_data_path.mkdir(exist_ok=True, parents=True)
     n_partitions = 10
-    get_data_partitioned = np.array_split(source_data, n_partitions)
+    # np.array_split returns ndarrays for DataFrames on numpy 2 / pandas 3,
+    # so split via positional indices to keep DataFrames
+    split_points = np.array_split(np.arange(len(source_data)), n_partitions)
+    get_data_partitioned = [source_data.iloc[idx] for idx in split_points]
     # save each part into a separate parquet file
     for i, df_part in enumerate(get_data_partitioned):
         part_fn = source_data_path / f"part.{i:06}.parquet"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Pull Request

## Changes

Fixes the remaining 10 failed / 2 errored unit tests in `tests/_data/unit` on `chore/update-engine-2.5.0-qa-1.10.4-github`, all caused by pandas 3.0 / numpy 2 / pyarrow 24 behavior changes that CI now picks up on this branch. Three small commits:

1. `mostlyai/sdk/_data/dtype.py` — restore `errors="ignore"` semantics for `VirtualInteger.cast` / `VirtualFloat.cast` (pandas 3 removed that value from `pd.to_numeric`); normalize `time_coerce`'s null output from `pd.NaT` to `pd.NA` for consistent equality.
2. `mostlyai/sdk/_data/file/table/json.py` — `Series.str[:-7]` → `Series.str.slice(stop=-7)` (pandas 3 removed `__getitem__` on the string accessor for pyarrow extension arrays).
3. `tests/_data/unit/test_finalize_generation.py`, `tests/_data/unit/test_push.py` — `np.array_split(df, n)` now returns ndarrays under numpy 2 / pandas 3; split via positional indices so each part stays a DataFrame. And compare the all-null column via `.isna()` instead of equality against `[None] * 9`.

## Why this change?

On PR #708 (engine 2.5.0 / qa 1.10.4 from GitHub) the CPU CI job was red. The E2E hang was already fixed in #709; the remaining failures are all unit tests in `tests/_data/unit` that regressed because pandas 3.0 / numpy 2.4 / pyarrow 24 changed behavior:

- `pd.to_numeric(..., errors="ignore")` now raises `ValueError: invalid error value specified`. Our `.cast()` methods used that to return input unchanged on non-numeric data; after the bump every `.cast()` raised, the outer `try/except` in `encompasses()` swallowed it, and `VirtualInteger/Float.encompasses()` silently returned `False` for valid int/float series (cascading into `VirtualInteger().encompass(int) == VirtualVarchar()` in `test_encompass_integer`).
- Under `object` dtype, pandas 3's `assert_series_equal` now distinguishes `pd.NaT` and `pd.NA`; `time_coerce` was returning `NaT` while tests asserted `<NA>`.
- `np.array_split(df, n)` now returns a list of ndarrays instead of DataFrames for a DataFrame input, breaking `df_part.to_parquet(...)` in two fixtures.
- `Series.str[key]` (`StringMethods.__getitem__`) no longer works on pyarrow-backed extension arrays; `Series.str.slice(...)` still does.
- `assert_frame_equal` with `check_dtype=False` still rejects `NaN` vs `None` for all-null columns.

The first two are real runtime bugs in `mostlyai/sdk/_data/` (they would hit users writing JSON or using auto-typing on pandas 3), not just test fragility.

## Testing

With the CI-matched env (`pandas==3.0.2`, `numpy==2.4.3`, `pyarrow==24.0.0`, engine 2.5.0 + qa 1.10.4 from git):

- `pytest -vv tests/_data/unit tests/_local/unit tests/client/unit tests/test_domain.py` → 380 passed, 2 skipped (the 2 skips are pre-existing `@pytest.mark.skip`s).
- `pytest -vv tests/_local/end_to_end -k 'not (client and mode)'` → 9 passed, 2 deselected (unchanged from after #709).

Each commit is scoped to one logical change so they can be cherry-picked or reverted independently.

## Additional Notes

Targets the PR #708 branch, not `main`. After #708 merges this can be folded in on top.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-04efc525-3f84-4320-8797-9c35a07ddfc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04efc525-3f84-4320-8797-9c35a07ddfc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

