### PR TITLE
chore: re-generate uv.lock after main updates

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -3323,7 +3323,7 @@ wheels = [
 
 [[package]]
 name = "mostlyai"
-version = "5.10.1"
+version = "5.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },
@@ -3474,10 +3474,10 @@ requires-dist = [
     { name = "joblib", marker = "extra == 'local'", specifier = ">=1.4.2" },
     { name = "joblib", marker = "extra == 'local-gpu'", specifier = ">=1.4.2" },
     { name = "kerberos", marker = "extra == 'hive'", specifier = ">=1.3.1,<2" },
-    { name = "mostlyai-engine", marker = "python_full_version >= '3.11' and extra == 'local'", git = "https://github.com/mostly-ai/mostlyai-engine.git?rev=2.5.0" },
-    { name = "mostlyai-engine", extras = ["gpu"], marker = "python_full_version >= '3.11' and extra == 'local-gpu'", git = "https://github.com/mostly-ai/mostlyai-engine.git?rev=2.5.0" },
-    { name = "mostlyai-qa", marker = "python_full_version >= '3.11' and extra == 'local'", git = "https://github.com/mostly-ai/mostlyai-qa.git?rev=1.10.4" },
-    { name = "mostlyai-qa", marker = "python_full_version >= '3.11' and extra == 'local-gpu'", git = "https://github.com/mostly-ai/mostlyai-qa.git?rev=1.10.4" },
+    { name = "mostlyai-engine", marker = "extra == 'local'", git = "https://github.com/mostly-ai/mostlyai-engine.git?rev=2.5.0" },
+    { name = "mostlyai-engine", extras = ["gpu"], marker = "extra == 'local-gpu'", git = "https://github.com/mostly-ai/mostlyai-engine.git?rev=2.5.0" },
+    { name = "mostlyai-qa", marker = "extra == 'local'", git = "https://github.com/mostly-ai/mostlyai-qa.git?rev=1.10.4" },
+    { name = "mostlyai-qa", marker = "extra == 'local-gpu'", git = "https://github.com/mostly-ai/mostlyai-qa.git?rev=1.10.4" },
     { name = "mysql-connector-python", marker = "extra == 'mysql'", specifier = ">=9.1.0,<10" },
     { name = "networkx", marker = "extra == 'local'", specifier = ">=3.0,<4" },
     { name = "networkx", marker = "extra == 'local-gpu'", specifier = ">=3.0,<4" },


### PR DESCRIPTION
## Summary
- Re-generated `uv.lock` after syncing this branch with the latest `main` updates.
- Updated resolved package metadata and dependency markers to match current project constraints.

## Test plan
- [x] Verified lockfile diff against `main`.
- [x] Confirmed branch is up to date with `origin/chore/update-uv-lock`.


Made with [Cursor](https://cursor.com)