### PR TITLE
ci: disable automatic GPU tests

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -18,20 +18,6 @@ jobs:
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)
     uses: ./.github/workflows/run-tests-cpu.yaml
     secrets: inherit
-  run-tests-gpu:
-    if: |
-      (
-        github.event_name == 'push' ||
-        (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)
-      ) &&
-      (
-        github.ref == 'refs/heads/main' ||
-        startsWith(github.ref, 'refs/tags/') ||
-        contains(github.event.head_commit.message, '[gpu]') ||
-        contains(github.event.pull_request.title, '[gpu]')
-      )
-    uses: ./.github/workflows/run-tests-gpu.yaml
-    secrets: inherit
   build-docker-image:
     if: |
       (
@@ -42,6 +28,6 @@ jobs:
         github.ref == 'refs/heads/main' ||
         startsWith(github.ref, 'refs/tags/')
       )
-    needs: [pre-commit-check, run-tests-cpu, run-tests-gpu]
+    needs: [pre-commit-check, run-tests-cpu]
     secrets: inherit
     uses: ./.github/workflows/build-docker-image.yaml

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -18,6 +18,12 @@ jobs:
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)
     uses: ./.github/workflows/run-tests-cpu.yaml
     secrets: inherit
+  run-tests-gpu:
+    if: |
+      (github.event_name == 'push' && contains(github.event.head_commit.message, '[gpu]')) ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.title, '[gpu]'))
+    uses: ./.github/workflows/run-tests-gpu.yaml
+    secrets: inherit
   build-docker-image:
     if: |
       (


### PR DESCRIPTION
## Summary
- remove the automatic GPU test job from the main CI workflow
- keep CPU tests and existing Docker-image gating in place

## Test plan
- [x] verify only `.github/workflows/workflow.yaml` changed

Made with [Cursor](https://cursor.com)